### PR TITLE
Adding Multiple Trip Locations

### DIFF
--- a/client/app/css/homepage.css
+++ b/client/app/css/homepage.css
@@ -130,15 +130,13 @@ button{
     backdrop-filter: blur(2px);
 }
 
-/* popup window content */
 .modal-content {
-    background-color: white;
-    padding: 30px;
-    border-radius: 8px;
-    width: 400px;
-    max-width: 90%; 
-    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
-    animation: fadeIn 0.3s ease-in-out;
+    max-height: 80vh; /* Maximum height of the modal */
+    overflow-y: auto; /* Enable vertical scrolling */
+    padding: 20px; /* Add some padding */
+    background-color: white; /* Background color */
+    border-radius: 8px; /* Optional: rounded corners */
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2); /* Optional: shadow effect */
 }
 
 form {

--- a/client/app/css/homepage.css
+++ b/client/app/css/homepage.css
@@ -240,6 +240,6 @@ form {
 }
 
 .location-text {
-    color: black; /* This will make the added location text black */
+    color: black;
     font-weight: bold;
 }

--- a/client/app/css/homepage.css
+++ b/client/app/css/homepage.css
@@ -220,3 +220,26 @@ form {
     cursor: pointer;
     z-index: 10000; 
 }
+
+.dropdown-suggestion {
+    color: black;
+    background-color: white;
+    padding: 8px;
+    cursor: pointer;
+}
+
+.dropdown-suggestion:hover {
+    background-color: rgb(8, 148, 8);
+}
+
+.selected-location {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 5px;
+}
+
+.location-text {
+    color: black; /* This will make the added location text black */
+    font-weight: bold;
+}

--- a/client/app/homepage/page.js
+++ b/client/app/homepage/page.js
@@ -46,6 +46,7 @@ function homepage() {
     });
     const [newTripLocation, setNewTripLocation] = useState({ trip_locations: '' });
     const mapRef = useRef(null); // Reference for the map
+    const [suggestions, setSuggestions] = useState([]);
 
     // Handle events
     const handleLogout = () => {
@@ -92,6 +93,33 @@ function homepage() {
     const newTripLocInputChange = (e) => {
         const { name, value } = e.target;
         setNewTripLocation({ ...newTripLocation, [name]: value });
+        fetchLocationSuggestions(value);
+    };
+
+    const fetchLocationSuggestions = async (query) => {
+        if (query) {
+            try {
+                const response = await axios.get(`https://api.opencagedata.com/geocode/v1/json`, {
+                    params: {
+                        q: query,
+                        key: process.env.NEXT_PUBLIC_OPENCAGE_API_KEY,
+                        limit: 5 // Limit the number of suggestions
+                    }
+                });
+                const results = response.data.results.map(result => result.formatted); // Extract formatted addresses
+                setSuggestions(results); // <-- Set suggestions state
+            } catch (error) {
+                console.error('Error fetching location suggestions:', error);
+                setSuggestions([]); // Clear suggestions on error
+            }
+        } else {
+            setSuggestions([]); // Clear suggestions if input is empty
+        }
+    };
+
+    const selectSuggestion = (suggestion) => {
+        setNewTripLocation({ trip_locations: suggestion }); // Set selected suggestion as input
+        setSuggestions([]); // Clear suggestions after selection
     };
 
     const submitNewTrip = async (e) => {
@@ -202,6 +230,16 @@ function homepage() {
                                     Budget:
                                     <input type="number" name="budget" value={newTripData.budget} onChange={newTripInputChange} required />
                                 </label>
+
+                                {suggestions.length > 0 && (
+                                    <ul className="suggestions-list">
+                                        {suggestions.map((suggestion, index) => (
+                                            <li key={index} onClick={() => selectSuggestion(suggestion)}> { }
+                                                {suggestion}
+                                            </li>
+                                        ))}
+                                    </ul>
+                                )}
 
                                 <label className="new-trip-field-label">
                                     Locations:

--- a/client/app/homepage/page.js
+++ b/client/app/homepage/page.js
@@ -19,6 +19,7 @@ import { Icon, Style } from 'ol/style';
 import Feature from 'ol/Feature';
 import Point from 'ol/geom/Point';
 import { fromLonLat } from 'ol/proj';
+import Link from 'next/link';
 
 // Custom marker icon style
 const customIconStyle = new Style({
@@ -239,7 +240,9 @@ function homepage() {
                                                 <strong>Dates:</strong> {trip.start_date} - {trip.end_date}
                                             </p>
                                             <p><strong>Budget:</strong> ${trip.budget}</p>
-                                            {/* Add more details as needed */}
+                                            <Link href={`/singletrip`} style={{ color: 'white', textDecoration: 'underline' }}>
+                                                See more
+                                            </Link>
                                         </div>
                                     )}
                                 </li>

--- a/client/app/homepage/page.js
+++ b/client/app/homepage/page.js
@@ -119,27 +119,30 @@ function homepage() {
     };
 
     const selectSuggestion = (suggestion) => {
-        if (!newTripLocation.trip_locations.includes(suggestion)) {
+        // Check if the suggestion is not already included and if the max limit is not reached
+        if (!newTripLocation.trip_locations.includes(suggestion) && newTripLocation.trip_locations.length < 10) {
             setNewTripLocation(prev => ({
                 trip_locations: [...prev.trip_locations, suggestion] // Add selected suggestion to locations array
             }));
+        } else if (newTripLocation.trip_locations.length >= 10) {
+            alert("You can only add a maximum of 10 locations."); // Alert if limit is reached
         }
         setSuggestions([]); // Clear suggestions after selection
         setTempLocation(''); // Clear input field after selection
-    };
+    };    
 
     const addLocation = () => {
-        // Check if tempLocation is in the suggestions array
-        if (tempLocation && suggestions.includes(tempLocation) && !newTripLocation.trip_locations.includes(tempLocation)) {
+        if (tempLocation && 
+            !newTripLocation.trip_locations.includes(tempLocation) && 
+            newTripLocation.trip_locations.length < 10) {
             setNewTripLocation(prev => ({
                 trip_locations: [...prev.trip_locations, tempLocation] // Add the new location to the array
             }));
             setTempLocation(''); // Clear the input
-        } else {
-            alert("Please select a location from the suggestions."); // Feedback for invalid input
+        } else if (newTripLocation.trip_locations.length >= 10) {
+            alert("You can only add a maximum of 10 locations."); // Alert if limit is reached
         }
-    };
-    
+    };   
 
     const submitNewTrip = async (e) => {
         e.preventDefault();
@@ -262,10 +265,27 @@ function homepage() {
                                         placeholder="Enter city or country"
                                         value={tempLocation}
                                         onChange={newTripLocInputChange}
-                                        onKeyDown={(e) => { if (e.key === 'Enter') addLocation(); }} // Allow adding on Enter
+                                        onKeyDown={(e) => { 
+                                            // Check if the Enter key is pressed and the limit has not been reached
+                                            if (e.key === 'Enter') {
+                                                if (newTripLocation.trip_locations.length < 10) {
+                                                    addLocation(); // Allow adding location
+                                                    e.preventDefault(); // Prevent form submission
+                                                } else {
+                                                    alert("You can only add a maximum of 10 locations."); // Alert if limit is reached
+                                                    e.preventDefault(); // Prevent form submission
+                                                }
+                                            }
+                                        }} 
                                         required
                                     />
-                                    <button type="button" onClick={addLocation}>Add Location</button>
+                                    <button 
+                                        type="button" 
+                                        onClick={addLocation} 
+                                        disabled={newTripLocation.trip_locations.length >= 10} // Disable button if limit reached
+                                    >
+                                        Add Location
+                                    </button>
                                 </label>
 
                                 <div>

--- a/client/app/homepage/page.js
+++ b/client/app/homepage/page.js
@@ -129,13 +129,17 @@ function homepage() {
     };
 
     const addLocation = () => {
-        if (tempLocation && !newTripLocation.trip_locations.includes(tempLocation)) {
+        // Check if tempLocation is in the suggestions array
+        if (tempLocation && suggestions.includes(tempLocation) && !newTripLocation.trip_locations.includes(tempLocation)) {
             setNewTripLocation(prev => ({
                 trip_locations: [...prev.trip_locations, tempLocation] // Add the new location to the array
             }));
             setTempLocation(''); // Clear the input
+        } else {
+            alert("Please select a location from the suggestions."); // Feedback for invalid input
         }
     };
+    
 
     const submitNewTrip = async (e) => {
         e.preventDefault();
@@ -267,7 +271,7 @@ function homepage() {
                                 <div>
                                     {newTripLocation.trip_locations.map((location, index) => (
                                         <div key={index} className="selected-location">
-                                            <span className="location-text">{location}</span> {/* Styled in black */}
+                                            <span className="location-text">{location}</span>
                                             <button onClick={() => {
                                                 setNewTripLocation(prev => ({
                                                     trip_locations: prev.trip_locations.filter((loc, i) => i !== index) // Remove selected location

--- a/client/app/homepage/page.js
+++ b/client/app/homepage/page.js
@@ -267,7 +267,7 @@ function homepage() {
                                 <div>
                                     {newTripLocation.trip_locations.map((location, index) => (
                                         <div key={index} className="selected-location">
-                                            {location}
+                                            <span className="location-text">{location}</span> {/* Styled in black */}
                                             <button onClick={() => {
                                                 setNewTripLocation(prev => ({
                                                     trip_locations: prev.trip_locations.filter((loc, i) => i !== index) // Remove selected location

--- a/client/app/singletrip/page.js
+++ b/client/app/singletrip/page.js
@@ -1,0 +1,12 @@
+'use client';
+
+import React from 'react';
+import '../css/singletrip.css';
+
+function Singletrip() {
+    return(
+        <p>SINGLEPAGE</p>
+    );
+}
+
+export default Singletrip;


### PR DESCRIPTION
## Description
- This PR allows a user to select multiple suggested locations in the dropdown feature for the create trips popup. They are limited to a max of 10 entries and can only add suggested locations (rather than their own typed ones). It also adds a link to the "See more" feature of trips so that it is sent to a default singletrip page view.
- This is for ticket #76 and prep for ticket #74
- Homepage's page.js and css file were added/changed.

## What’s in this change?
- (Homepage) page.js: This has all the main features, including allowing users to select multiple locations, limiting them to 10, linking to singletrip page, etc. (See above for details.)
- homepage.css: Added stylization to make the dropdown suggestions look better (i.e. added black text, green highlight, etc)
- (Singletrip) page.js: This just contains a default singlepage with a print statement. It is just to initialize the new page so that it can be linked to.
- singletrip.css:  This is blank, it's just setup for the ticket.

## Testing Changes
- No testing conducted.
- Unit tests not set up yet.
