### PR TITLE
Basic edit and delete expense button created

### DIFF
--- a/client/app/css/singletrip.css
+++ b/client/app/css/singletrip.css
@@ -391,4 +391,41 @@
     gap: 10px;
 }
 
+.edit-expense {
+    background-color: #134a09;
+    position: relative;
+    padding: 5px 10px;
+    font-size: 14px;
+    color: white;
+    border-radius: 8px;
+    border: none;
+    cursor: pointer;
+    text-align: center;
+    transition: all 0.5s;
+    overflow: hidden;
+    box-shadow: none;
+}
 
+.edit-expense:after {
+    content: '-';
+    position: absolute;
+    opacity: 0;
+    top: 50%;
+    right: -40px;
+    transform: translateY(-50%);
+    transition: 0.2s ease-in-out;
+    font-size: 30px;
+    color: white;
+}
+
+.edit-expense:hover {
+    color: transparent;
+    /* hide text */
+    padding-right: 10px;
+}
+
+.edit-expense:hover:after {
+    opacity: 1;
+    right: 50%;
+    transform: translate(50%, -50%);
+}

--- a/client/app/singletrip/page.js
+++ b/client/app/singletrip/page.js
@@ -24,6 +24,8 @@ function Singletrip() {
     const [currencyCodes, setCurrencyCodes] = useState([]);
     const [isPopUpVisible, setPopUpVisible] = useState(false);
     const [isFilterPopupVisible, setFilterPopupVisible] = useState(false);
+    const [isEditPopupVisible, setEditPopupVisible] = useState(false);
+    const [selectedExpense, setSelectedExpense] = useState(null);
     const [originalData, setOriginalData] = useState([]);
     const [selectedFilter, setSelectedFilter] = useState('');
     const [newExpenseData, setNewExpenseData] = useState({
@@ -130,6 +132,13 @@ function Singletrip() {
             });
 
     }, []);
+
+    const submitEditExpense = async (e) => {
+        e.preventDefault(); 
+        // API CALL
+        alert("Editing is still a WIP :)");
+        setEditPopupVisible(false);
+    };
 
     const downloadTripData = async () => {
         try {
@@ -373,6 +382,7 @@ function Singletrip() {
                                         <th>Currency</th>
                                         <th>Date Posted</th>
                                         <th>Notes</th>
+                                        <th>Edit/Delete Expense</th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -384,6 +394,89 @@ function Singletrip() {
                                             <td>{expense.currency}</td>
                                             <td>{expense.posted}</td>
                                             <td>{expense.notes}</td>
+                                            <td>
+                                                <button onClick={() => { setEditPopupVisible(true); setSelectedExpense(expense) }} className='edit-expense'>Edit/Delete Expense</button>
+                                                <div className="expense-form">
+                                                    {isEditPopupVisible && selectedExpense && (
+                                                        <div className="modal">
+                                                            <div className="modal-content">
+                                                                <span className="close" onClick={() => setEditPopupVisible(false)}>&times;</span>
+                                                                <h2 className="edit-expense-title">Edit or Delete this Expense</h2>
+                                                                <form onSubmit={submitEditExpense}>
+                                                                    <label className="edit-expense-field-label">
+                                                                        Expense Name:
+                                                                        <input
+                                                                            type="text"
+                                                                            name="name"
+                                                                            value={selectedExpense.name}
+                                                                            // onChange={newExpenseInputChange}
+                                                                            required
+                                                                        />
+                                                                    </label>
+                                                                    <label className="edit-expense-field-label">
+                                                                        Amount:
+                                                                        <input
+                                                                            type="number"
+                                                                            name="amount"
+                                                                            value={selectedExpense.amount}
+                                                                            // onChange={newExpenseInputChange}
+                                                                            required
+                                                                        />
+                                                                    </label>
+                                                                    <label className="edit-expense-field-label">
+                                                                        Currency:
+                                                                        <select
+                                                                            name="currency"
+                                                                            value={selectedExpense.currency}
+                                                                            // onChange={newExpenseInputChange}
+                                                                            required
+                                                                        >
+                                                                            <option value="">Select Currency</option>
+                                                                            {currencyCodes.map((code) => (
+                                                                                <option key={code} value={code}>{code}</option>
+                                                                            ))}
+                                                                        </select>
+                                                                    </label>
+                                                                    <label className="edit-expense-field-label">
+                                                                        Category:
+                                                                        <select
+                                                                            name="category"
+                                                                            value={selectedExpense.category}
+                                                                            // onChange={newExpenseInputChange}
+                                                                            required
+                                                                        >
+                                                                            <option value="">Select Category</option>
+                                                                            {expenseCategories.map((category) => (
+                                                                                <option key={category} value={category}>{category}</option>
+                                                                            ))}
+                                                                        </select>
+                                                                    </label>
+                                                                    <label className="edit-expense-field-label">
+                                                                        Date:
+                                                                        <input
+                                                                            type="date"
+                                                                            name="posted"
+                                                                            value={selectedExpense.posted}
+                                                                            // onChange={newExpenseInputChange}
+                                                                            required
+                                                                        />
+                                                                    </label>
+                                                                    <label className="edit-expense-field-label">
+                                                                        Notes:
+                                                                        <input
+                                                                            type="text"
+                                                                            name="notes"
+                                                                            value={selectedExpense.notes}
+                                                                        // onChange={newExpenseInputChange}
+                                                                        />
+                                                                    </label>
+                                                                    <button type="submit" className="submit-edit-expense-button">Edit</button>
+                                                                </form>
+                                                            </div>
+                                                        </div>
+                                                    )}
+                                                </div>
+                                            </td>
                                         </tr>
                                     ))}
                                 </tbody>

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1294,6 +1294,7 @@
     },
     "node_modules/react": {
       "version": "18.3.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -1387,6 +1388,7 @@
     },
     "node_modules/react-dom": {
       "version": "18.3.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -1498,6 +1500,7 @@
     },
     "node_modules/scheduler": {
       "version": "0.23.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"


### PR DESCRIPTION
## Description
- The purpose of this PR is to create the button for each expense to either modify or delete it.
- This PR belongs to ticket #94 
- `singletrip.css` and `singletrip/page.js`

## What’s in this change?
- `singletrip/page.js`
  - Added a button that opens up a form that has the data of the expense it belongs to already filled out so that it's easier for the user to modify its data.
  - For now, clicking the edit button inside the pop-up form will just display an alert.
- `singletrip.css`
  - Added the cs for the button to fit nicely in it's cell and have an animation.

## Testing Changes
- No unit tests for this.
- Checked different trips and expenses to ensure that the pop-up form was filling itself with the correct expense data.
