### PR TITLE
Converted budget meter to USD and added budget data box

### DIFF
--- a/client/app/singletrip/page.js
+++ b/client/app/singletrip/page.js
@@ -26,7 +26,7 @@ function Singletrip() {
     const [tripData, setTripData] = useState(null);
     const [userRole, setUserRole] = useState(null);
     const [expenseData, setExpenseData] = useState([]);
-    const [totalExpenses, setTotalExpenses] = useState(0);
+    const [totalUSDExpenses, setTotalUSDExpenses] = useState(0);
     const [currencyCodes, setCurrencyCodes] = useState([]);
     const [selectedCurrency, setSelectedCurrency] = useState('');
     const [otherCurrencies, setOtherCurrencies] = useState([]);
@@ -85,12 +85,6 @@ function Singletrip() {
                         applyFilter(savedFilter, response.data);
                     }
 
-                    const total = response.data.data.reduce((sum, expense) => {
-                        const amount = parseFloat(expense.amount);
-                        return sum + amount;
-                    }, 0);
-
-                    setTotalExpenses(total);
                     fetchCurrencyRates(fetchedExpenses);
                 })
                 .catch(error => {
@@ -200,6 +194,8 @@ function Singletrip() {
                         categoryTotals[expense.category] = 0;
                     }
                     categoryTotals[expense.category] += parseFloat(amountInUSD);
+
+                    setTotalUSDExpenses(prevTotal => prevTotal + parseFloat(amountInUSD));
 
                     return {
                         ...expense,
@@ -526,15 +522,15 @@ function Singletrip() {
                                 <div className='col'>
                                     <div className="meter-container">
                                         <p id='budgetTitle'>Your Budget Meter:</p>
-
-                                        {totalExpenses > tripData.data.budget ? (
+                                        {expenseData && expenseData.data && totalUSDExpenses === 0 ? (
+                                            <p>Loading your budget data...</p>
+                                        ) : totalUSDExpenses > tripData.data.budget ? (
                                             <div style={{
                                                 marginTop: "10px",
                                                 width: "350px",
-                                                height: "230px",
+                                                height: "200px",
                                                 marginLeft: "50px"
                                             }}>
-                                                <p id='budget-text'>You are {totalExpenses - tripData.data.budget} dollars over your budget.</p>
                                                 <ReactSpeedometer
                                                     width={300}
                                                     minValue={0}
@@ -544,7 +540,7 @@ function Singletrip() {
                                                     needleTransitionDuration={2500}
                                                     needleTransition={Transition.easeBounceOut}
                                                     segments={4}
-                                                    segmentColors={['#7ada2c', '#d4e725', '#f3a820', '#fe471a']}
+                                                    segmentColors={['#b3e5fc', '#ffe0b2', '#ffccbc', '#d1c4e9']}
                                                 />
                                             </div>
                                         ) : (
@@ -558,7 +554,7 @@ function Singletrip() {
                                                     width={300}
                                                     minValue={0}
                                                     maxValue={tripData.data.budget}
-                                                    value={totalExpenses}
+                                                    value={totalUSDExpenses.toFixed(2)}
                                                     needleColor="steelblue"
                                                     needleTransitionDuration={2500}
                                                     needleTransition={Transition.easeBounceOut}
@@ -569,6 +565,25 @@ function Singletrip() {
                                         )}
                                     </div>
                                 </div>
+                                <div className='col'>
+                                    <div className="meter-container">
+                                        <p id='budgetTitle'>Your Budget Data:</p>
+                                        {expenseData && expenseData.data && totalUSDExpenses === 0 ? (
+                                            <p>Loading your budget data...</p>
+                                        ) : (
+                                            <div style={{ textAlign: 'center', margin: '20px' }}>
+                                                <p style={{ textDecoration: "underline" }}>Total Expenses in USD:</p>
+                                                <p>${totalUSDExpenses.toFixed(2)}</p>
+                                                {totalUSDExpenses > tripData.data.budget ? (
+                                                    <p id='budget-text'>You are <strong>${(totalUSDExpenses - tripData.data.budget).toFixed(2)}</strong> over your budget.</p>
+                                                ) : (
+                                                    <p>You are within your budget.</p>
+                                                )}
+                                            </div>
+                                        )}
+                                    </div>
+                                </div>
+
                             </div>
                         </div>
 


### PR DESCRIPTION
## Description
- The purpose of this PR is to convert the budget meter to convert the total expenses calculated for the budget meter to be in USD.
- This PR belongs to ticket #113 and part of #99 
- Modified `singletrip/page.js`

## What’s in this change?
- `singletrip/page.js`
  - Changed the way total expenses were calculated by converting each expense to USD and adding them to the total.
  - Changed the way the budget meter is dynamically displayed. Since there's a delay in getting the totalExpenses value in USD, if there are expenses but totalUSDExpenses is still 0, the user is told that the data is loading. Once expenses load or there are no expenses then the budget meter is displayed and shows the total amount in USD.
  - Added a budget data box that displays dynamically similarly to the budget meter box.
  
## Testing Changes
- No unit tests applicable because these are frontend changes.
- Checked if the budget meter is displayed properly depending on if there are no expenses, if the expenses are still loading, and if there are expenses.
- Checked if the total expenses in USD are being printed properly and it's subtraction from the budget is printing properly.
- Checked edge cases for the subtraction (for example just being 1 cent away from each other)
