### PR TITLE
New Expense Table and Reorganize Single Trip

### DIFF
--- a/client/app/components/singletrip/ExpenseTableComponent.js
+++ b/client/app/components/singletrip/ExpenseTableComponent.js
@@ -3,9 +3,7 @@ import axios from 'axios';
 import Table from 'react-bootstrap/Table';
 import '../../css/ExpenseTableComponent.css';
 
-import { Card, CardContent, Typography, Button, Grid, Dialog, DialogTitle, DialogContent, DialogActions } from '@mui/material';
-
-const ExpenseTableComponent = ({ tripData, tripId, tripLocations , expenseData, currencyCodes, expenseCategories, userRole}) => {
+const ExpenseTableComponent = ({ tripData, tripId, tripLocations, expenseData, currencyCodes, expenseCategories, categoryData }) => {
     const [isEditPopupVisible, setEditPopupVisible] = useState(false);
     const [selectedExpense, setSelectedExpense] = useState(null);
     const handleEditChange = (e) => {
@@ -45,82 +43,35 @@ const ExpenseTableComponent = ({ tripData, tripId, tripLocations , expenseData, 
     const getCategoryIcon = (category) => {
         switch (category) {
             case 'Flights':
-                return '✈️'; 
+                return '✈️';
             case 'Accommodations':
-                return '🏨'; 
+                return '🏨';
             case 'Food/Drink':
-                return '🍽️'; 
+                return '🍽️';
             case 'Transport':
-                return '🚗'; 
+                return '🚗';
             case 'Activities':
-                return '🎢'; 
+                return '🎢';
             case 'Shopping':
-                return '🛍️'; 
+                return '🛍️';
             case 'Phone/Internet':
-                return '📱'; 
+                return '📱';
             case 'Health/Safety':
                 return '🚑';
             case 'Other':
-                return '🌈'; 
+                return '🌈';
         }
     };
 
-    const getCategoryColor = (category) => {
-        switch (category) {
-            case 'Flights':
-                return '#4A90E2'; // Blue
-            case 'Accommodations':
-                return '#7B1FA2'; // Purple
-            case 'Food/Drink':
-                return '#FF5722'; // Orange
-            case 'Transport':
-                return '#2E7D32'; // Green
-            case 'Activities':
-                return '#FFEB3B'; // Yellow
-            case 'Shopping':
-                return '#FF4081'; // Pink
-            case 'Phone/Internet':
-                return '#3F51B5'; // Indigo
-            case 'Health/Safety':
-                return '#F44336'; // Red
-            case 'Other':
-                return '#9E9E9E'; // Grey
-            default:
-                return '#000000'; // Default color
-        }
-    };
+    // console.log(categoryData)
+    // console.log(categoryData.labels)
 
-    const formatDate = (dateString) => {
-        const date = new Date(dateString);
-        const options = { month: 'long', day: 'numeric' };
-        return date.toLocaleDateString('en-US', options);
-    };
-
-    const getNameIcon = (name, category) => {
-        const words = name.split(' ');
-        let initials = '';
-    
-        // if (words.length === 1) {
-        //     initials = words[0].substring(0, 2).toUpperCase();
-        // } else if (words.length > 1) {
-        //     initials = words[0][0].toUpperCase() + words[1][0].toUpperCase();
-        // }
-    
-        return (
-            <span className="name-icon" style={{ backgroundColor: getCategoryColor(category) }}>
-                {initials}
-            </span>
-        );
-    };
-    
-    
-    
     return (
-        <div> 
-            {expenseData && expenseData.data ? (
+        <div>
+            {expenseData && expenseData.data && categoryData.datasets && categoryData.datasets.length > 0 ? (
                 <div>
                     <div className="expense-table-container">
-                        <Table  bordered hover size="sm" >
+                        <Table hover size="sm" responsive="sm" className="expense-table">
                             <thead>
                                 <tr>
                                     <th>Name</th>
@@ -129,159 +80,149 @@ const ExpenseTableComponent = ({ tripData, tripId, tripLocations , expenseData, 
                                     <th>Category</th>
                                     <th>Date</th>
                                     <th>Notes</th>
-                                    {userRole == 'owner' || userRole == 'editor' ? <th>Edit</th> : null}
+                                    <th>Edit</th>
                                 </tr>
                             </thead>
                             <tbody>
-                            {/* Start of mapping through expenseData.data */}
-                            {expenseData.data.map((expense) => {
-                                // Define the color for the current expense category
-                                const categoryColor = getCategoryColor(expense.category);
-                                
-                                return (
-                                    // Start of a table row for each expense
-                                    <tr key={expense.expense_id}>
-                                        
-                                        {/* Name cell with color and icon */}
-                                        <td style={{ color: categoryColor }}>
-                                            {getNameIcon(expense.name, expense.category)} {expense.name}
-                                        </td>
-                                        
-                                        {/* Amount cell with color and "+" sign */}
-                                        <td style={{ color: categoryColor }} className="amount-cell">
-                                            {`+${expense.amount}`}
-                                        </td>
-                                        
-                                        {/* Currency cell with color */}
-                                        <td style={{ color: categoryColor }}>{expense.currency}</td>
-                                        
-                                        {/* Category cell with icon and color */}
-                                        <td style={{ color: categoryColor }}>
-                                            {getCategoryIcon(expense.category)} {expense.category}
-                                        </td>
-                                        
-                                        {/* Date cell with color */}
-                                        <td style={{ color: categoryColor }}>{formatDate(expense.posted)}</td>
-                                        
-                                        {/* Notes cell with color */}
-                                        <td style={{ color: categoryColor }}>{expense.notes}</td>
+                                {expenseData.data.map((expense) => {
+                                    const categoryIndex = categoryData.labels.indexOf(expense.category);
+                                    const tagColor = categoryData.datasets[0].backgroundColor[categoryIndex];
 
-                                        
-                                        {/* Edit button cell with color */}
-                                        {userRole == 'owner' || userRole == 'editor' ? (
-                                        <td style={{ color: categoryColor }}>
-                                            {/* <div onClick={() => { setEditPopupVisible(true); setSelectedExpense(expense) }} className='edit-expense'>Edit Expense</div> */}
-                                            <div className="icon-div" tooltip="Edit Trip" tabIndex="0">
-                                                <div className="icon-SVG">
-                                                    <svg
-                                                        onClick={() => {
-                                                            setEditPopupVisible(true);
-                                                            setSelectedExpense(expense);
-                                                        }}
-                                                        xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke={categoryColor} className="size-6">
-                                                        <path strokeLinecap="round" strokeLinejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
-                                                    </svg>
-                                                    <span className="icon-text">Edit Expense</span>
+                                    return (
+                                        <tr key={expense.expense_id}>
+                                            <td>{expense.name}</td>
+                                            <td>{expense.amount}</td>
+                                            <td>{expense.currency}</td>
+                                            <td>
+                                                {/* Category with color tag */}
+                                                <span
+                                                    className="category-tag"
+                                                    style={{
+                                                        backgroundColor: tagColor,
+                                                        color: 'white',
+                                                        padding: '5px 10px',
+                                                        borderRadius: '20px',
+                                                        textTransform: 'capitalize',
+                                                        fontWeight: 'bold'
+                                                    }}
+                                                >
+                                                    {getCategoryIcon(expense.category)} {expense.category}
+                                                </span>
+                                            </td>
+                                            {/* <td>{getCategoryIcon(expense.category)} {expense.category}</td> */}
+                                            <td>{expense.posted.split('-')[1]}/{expense.posted.split('-')[2]}/{expense.posted.split('-')[0]} </td>
+                                            <td>{expense.notes}</td>
+                                            <td>
+                                                <div className="icon-div" tooltip="Edit Trip" tabIndex="0">
+                                                    <div className="icon-SVG">
+                                                        <svg
+                                                            onClick={() => {
+                                                                setEditPopupVisible(true);
+                                                                setSelectedExpense(expense);
+                                                            }}
+                                                            xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="size-6">
+                                                            <path strokeLinecap="round" strokeLinejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
+                                                        </svg>
+                                                        <span className="icon-text">Edit Expense</span>
+                                                    </div>
                                                 </div>
-                                            </div>
-                                            <div className="expense-form">
-                                                {isEditPopupVisible && selectedExpense && (
-                                                    <div className="modal">
-                                                        <div className="modal-content">
-                                                            <span className="close" onClick={() => setEditPopupVisible(false)}>&times;</span>
-                                                            <h2 className="edit-expense-title">Edit or Delete Expense</h2>
-                                                            <form onSubmit={(e) => {
-                                                                e.preventDefault();
-                                                                submitEditExpense(selectedExpense.expense_id);
-                                                            }}>
-                                                                <label className="edit-expense-field-label">
-                                                                    Expense Name:
-                                                                    <input
-                                                                        type="text"
-                                                                        name="name"
-                                                                        value={selectedExpense.name}
-                                                                        onChange={handleEditChange}
-                                                                        required
-                                                                    />
-                                                                </label>
-                                                                <div className="field-pair">
+                                                <div className="expense-form">
+                                                    {isEditPopupVisible && selectedExpense && (
+                                                        <div className="modal">
+                                                            <div className="modal-content">
+                                                                <span className="close" onClick={() => setEditPopupVisible(false)}>&times;</span>
+                                                                <h2 className="edit-expense-title">Edit or Delete Expense</h2>
+                                                                <form onSubmit={(e) => {
+                                                                    e.preventDefault();
+                                                                    submitEditExpense(selectedExpense.expense_id);
+                                                                }}>
                                                                     <label className="edit-expense-field-label">
-                                                                        Amount:
+                                                                        Expense Name:
                                                                         <input
-                                                                            type="number"
-                                                                            name="amount"
-                                                                            value={selectedExpense.amount}
+                                                                            type="text"
+                                                                            name="name"
+                                                                            value={selectedExpense.name}
                                                                             onChange={handleEditChange}
                                                                             required
                                                                         />
                                                                     </label>
+                                                                    <div className="field-pair">
+                                                                        <label className="edit-expense-field-label">
+                                                                            Amount:
+                                                                            <input
+                                                                                type="number"
+                                                                                name="amount"
+                                                                                value={selectedExpense.amount}
+                                                                                onChange={handleEditChange}
+                                                                                required
+                                                                            />
+                                                                        </label>
+                                                                        <label className="edit-expense-field-label">
+                                                                            Currency:
+                                                                            <select
+                                                                                name="currency"
+                                                                                value={selectedExpense.currency}
+                                                                                onChange={handleEditChange}
+                                                                                required
+                                                                            >
+                                                                                <option value="">Select Currency</option>
+                                                                                {currencyCodes.map((code) => (
+                                                                                    <option key={code} value={code}>{code}</option>
+                                                                                ))}
+                                                                            </select>
+                                                                        </label>
+                                                                    </div>
+                                                                    <div className="field-pair">
+                                                                        <label className="edit-expense-field-label">
+                                                                            Category:
+                                                                            <select
+                                                                                name="category"
+                                                                                value={selectedExpense.category}
+                                                                                onChange={handleEditChange}
+                                                                                required
+                                                                            >
+                                                                                <option value="">Select Category</option>
+                                                                                {expenseCategories.map((category) => (
+                                                                                    <option key={category} value={category}>{category}</option>
+                                                                                ))}
+                                                                            </select>
+                                                                        </label>
+                                                                        <label className="edit-expense-field-label">
+                                                                            Date:
+                                                                            <input
+                                                                                type="date"
+                                                                                name="posted"
+                                                                                value={selectedExpense.posted}
+                                                                                onChange={handleEditChange}
+                                                                                required
+                                                                            />
+                                                                        </label>
+                                                                    </div>
                                                                     <label className="edit-expense-field-label">
-                                                                        Currency:
-                                                                        <select
-                                                                            name="currency"
-                                                                            value={selectedExpense.currency}
-                                                                            onChange={handleEditChange}
-                                                                            required
-                                                                        >
-                                                                            <option value="">Select Currency</option>
-                                                                            {currencyCodes.map((code) => (
-                                                                                <option key={code} value={code}>{code}</option>
-                                                                            ))}
-                                                                        </select>
-                                                                    </label>
-                                                                </div>
-                                                                <div className="field-pair">
-                                                                    <label className="edit-expense-field-label">
-                                                                        Category:
-                                                                        <select
-                                                                            name="category"
-                                                                            value={selectedExpense.category}
-                                                                            onChange={handleEditChange}
-                                                                            required
-                                                                        >
-                                                                            <option value="">Select Category</option>
-                                                                            {expenseCategories.map((category) => (
-                                                                                <option key={category} value={category}>{category}</option>
-                                                                            ))}
-                                                                        </select>
-                                                                    </label>
-                                                                    <label className="edit-expense-field-label">
-                                                                        Date:
+                                                                        Notes:
                                                                         <input
-                                                                            type="date"
-                                                                            name="posted"
-                                                                            value={selectedExpense.posted}
+                                                                            type="text"
+                                                                            name="notes"
+                                                                            value={selectedExpense.notes}
                                                                             onChange={handleEditChange}
-                                                                            required
                                                                         />
                                                                     </label>
-                                                                </div>
-                                                                <label className="edit-expense-field-label">
-                                                                    Notes:
-                                                                    <input
-                                                                        type="text"
-                                                                        name="notes"
-                                                                        value={selectedExpense.notes}
-                                                                        onChange={handleEditChange}
-                                                                    />
-                                                                </label>
-                                                                <div className='container'>
-                                                                    <div className='row'>
-                                                                        <div className='col'>
-                                                                            <button type="submit" className="submit-edit-expense-button">Edit</button>
-                                                                        </div>
-                                                                        <div className='col'>
-                                                                            <button type="button" onClick={() => deleteExpense(selectedExpense.expense_id)} className="delete-expense-button">Delete</button>
+                                                                    <div className='container'>
+                                                                        <div className='row'>
+                                                                            <div className='col'>
+                                                                                <button type="submit" className="submit-edit-expense-button">Edit</button>
+                                                                            </div>
+                                                                            <div className='col'>
+                                                                                <button type="button" onClick={() => deleteExpense(selectedExpense.expense_id)} className="delete-expense-button">Delete</button>
+                                                                            </div>
                                                                         </div>
                                                                     </div>
-                                                                </div>
-                                                            </form>
+                                                                </form>
+                                                            </div>
                                                         </div>
-                                                    </div>
-                                                )}
-                                            </div>
+                                                    )}
+                                                </div>
                                             </td>
-                                        ) : null}
                                         </tr>
                                     );
                                 })}
@@ -295,6 +236,5 @@ const ExpenseTableComponent = ({ tripData, tripId, tripLocations , expenseData, 
         </div>
     );
 };
-
 
 export default ExpenseTableComponent;

--- a/client/app/css/ExpenseTableComponent.css
+++ b/client/app/css/ExpenseTableComponent.css
@@ -1,19 +1,36 @@
 .expense-table-container {
-    background-color: transparent; /* Remove any background color */
-    box-shadow: none; /* Remove any shadow if present */
-    border: none; /* Remove any borders if there are any */
+    width: 90%;
+    margin: 0 auto;
+    max-height: 400px; 
+    overflow-y: auto; 
+    overflow-x: hidden;
 }
 
-.name-icon {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 32px; /* Adjust size as needed */
-    height: 32px; /* Make height equal to width for a perfect circle */
-    border-radius: 50%; /* This makes it a circle */
-    background-color: inherit; /* The color will be inherited from the inline style */
-    color: white; /* Ensure text is visible against background */
-    font-weight: bold;
-    font-size: 0.9rem;
-    margin-right: 8px; /* Space between icon and name text */
+.expense-table th {
+    text-align: center;
+    padding: auto;
+    position: sticky;
+    top: 0;
+    background-color: #134a09 !important;
+    color: white !important;
+    z-index: 1;
+    font-size: 18px;
+}
+
+.expense-table td {
+    text-align: center;
+    vertical-align: middle;
+    padding: 10px;
+    border-color: #134a09;
+}
+
+.expense-table td:nth-child(2) {
+    text-align: center;
+}
+
+.expense-table td:nth-child(3),
+.expense-table td:nth-child(4),
+.expense-table td:nth-child(5),
+.expense-table td:nth-child(7) {
+    text-align: center;
 }

--- a/client/app/css/singletrip.css
+++ b/client/app/css/singletrip.css
@@ -352,6 +352,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
+    z-index: 2;
 }
 
 .filter-popup-content {
@@ -394,6 +395,7 @@
     width: 100%;
     margin-bottom: 10px;
     transition: background-color 0.3s ease, color 0.3s ease;
+    text-align: center;
 }
 
 .filter-option-button:hover {
@@ -426,42 +428,6 @@
     display: flex;
     align-items: center;
     gap: 10px;
-}
-
-.expense-table-container {
-    width: 64.5%;
-    float: left;
-    padding: 10px;
-    background-color: #f5f5f5;
-    border-radius: 10px;
-    box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.1);
-    margin-left: 20px;
-    max-height: 400px; 
-    overflow-y: auto; 
-    overflow-x: hidden; 
-    margin-right: 20px;
-}
-
-.expense-table th {
-    text-align: center;
-    padding: auto;
-}
-
-.expense-table td {
-    text-align: left;
-    vertical-align: middle;
-    padding: 10px;
-}
-
-.expense-table td:nth-child(2) {
-    text-align: right;
-}
-
-.expense-table td:nth-child(3),
-.expense-table td:nth-child(4),
-.expense-table td:nth-child(5),
-.expense-table td:nth-child(7) {
-    text-align: center;
 }
 
 .edit-expense {
@@ -599,17 +565,14 @@
 }
 
 .icon-bar-header {
-    /* width: 490px;
-    padding: 0 14px;
-    display: flex;
+    width: 90%;
+    justify-content: space-between;
     align-items: center;
-    background-color: white;
-    margin-left: 5 px; */
     display: flex;
     align-items: center;
     padding: 20px; /* Adjust spacing as needed */
     background-color: white; /* Optional background color */
-    margin: 0; /* Center the icon bar */
+    margin: 0 auto; /* Center the icon bar */
 }
 
 .icon-div {

--- a/client/app/css/singletrip.css
+++ b/client/app/css/singletrip.css
@@ -481,7 +481,7 @@
 
 
 .exchange-rates-container {
-    width:30%;
+    /* width:30%; */
     max-width: 600px;
     overflow: hidden;
     padding: 20px;
@@ -768,10 +768,12 @@
 }
 
 .circle-card {
+    margin-top: -30px;
     background-color: #f5f5f5;
     text-align: center;
     border-radius: 50%;
     width: 100%; 
+    width: 200px;
     max-width: 200px; 
     aspect-ratio: 1; 
     display: flex;

--- a/client/app/singletrip/page.js
+++ b/client/app/singletrip/page.js
@@ -47,7 +47,7 @@ function Singletrip() {
     const [originalData, setOriginalData] = useState([]);
     const [selectedFilter, setSelectedFilter] = useState('');
     const [tripLocations, setTripLocations] = useState([]);
-    const [selectedCategory, setSelectedCategory]= useState('');
+    const [selectedCategory, setSelectedCategory] = useState('');
     const [isDropdownVisible, setIsDropdownVisible] = useState(false);
     const [newExpenseData, setNewExpenseData] = useState({
         trip_id: '',
@@ -82,7 +82,7 @@ function Singletrip() {
             }
         }
     }, []);
-    
+
     // Fetch home currency when userId changes
     useEffect(() => {
         const getHomeCurrency = async () => {
@@ -93,7 +93,7 @@ function Singletrip() {
                 }
             }
         };
-    
+
         getHomeCurrency(); // Fetch home currency when userId is available
     }, [userId]);
 
@@ -112,8 +112,8 @@ function Singletrip() {
     useEffect(() => {
         const savedFilter = localStorage.getItem('selectedFilter');
         if (savedFilter && expenseUSD.length > 0) {
-            console.log(expenseUSD); 
-            applyFilter(savedFilter, expenseUSD); 
+            console.log(expenseUSD);
+            applyFilter(savedFilter, expenseUSD);
         }
     }, [expenseUSD]);
 
@@ -193,8 +193,8 @@ function Singletrip() {
     };
 
     const handleAllCategoriesSelect = () => {
-        setSelectedCategory(""); 
-        setExpenseData({ data: expenseUSD }); 
+        setSelectedCategory("");
+        setExpenseData({ data: expenseUSD });
         setIsDropdownVisible(false);
     };
 
@@ -204,23 +204,21 @@ function Singletrip() {
     };
 
 
-    useEffect(()=>{
-        if(selectedCategory)
-        {
+    useEffect(() => {
+        if (selectedCategory) {
             applyCategoryFilter();
         }
 
-    },[selectedCategory]);
+    }, [selectedCategory]);
 
-    const applyCategoryFilter=()=>{
+    const applyCategoryFilter = () => {
 
-        let filteredData=[];
+        let filteredData = [];
 
-        if(selectedCategory){
-            expenseUSD.forEach(expense=>{
+        if (selectedCategory) {
+            expenseUSD.forEach(expense => {
 
-                if(expense.category===selectedCategory)
-                {
+                if (expense.category === selectedCategory) {
                     filteredData.push(expense);
                 }
             })
@@ -325,7 +323,7 @@ function Singletrip() {
             });
 
     }, [tripId]);
-    
+
     useEffect(() => {
         if (homeCurrency) {
             // Only call fetchCurrencyRates when homeCurrency is successfully fetched
@@ -385,28 +383,28 @@ function Singletrip() {
                     const targetCurrency = expense.currency;
                     return axios.get(`https://hexarate.paikama.co/api/rates/latest/${targetCurrency}?target=${homeCurrency}`);
                 });
-    
+
             if (currencyPromises.length > 0) {
                 const currencyResponses = await Promise.all(currencyPromises);
                 const currencyRates = currencyResponses.map((response, index) => ({
                     currency: expenses[index].currency,
                     rate: response.data.data.mid // Assuming correct response structure
                 }));
-    
+
                 // Convert expenses to homeCurrency and accumulate category data
                 const categoryTotals = {};
                 const convertedExpenses = expenses.map((expense, index) => {
                     const rate = currencyRates.find(rate => rate.currency === expense.currency)?.rate || 1;
                     const amountInHomeCurrency = (parseFloat(expense.amount) * rate).toFixed(2);
-    
+
                     // Accumulate totals by category
                     if (!categoryTotals[expense.category]) {
                         categoryTotals[expense.category] = 0;
                     }
                     categoryTotals[expense.category] += parseFloat(amountInHomeCurrency);
-    
+
                     setTotalExpenses(prevTotal => prevTotal + parseFloat(amountInHomeCurrency));
-    
+
                     return {
                         ...expense,
                         amountInHomeCurrency // Add converted amount to expense
@@ -415,11 +413,11 @@ function Singletrip() {
 
                 setconvertedHomeCurrencyExpenseData(convertedExpenses)
                 setExpenseUSD(convertedExpenses);
-    
+
                 // Prepare data for pie chart
                 const labels = Object.keys(categoryTotals);
                 const data = Object.values(categoryTotals);
-    
+
                 setCategoryData({
                     labels,
                     datasets: [{
@@ -438,7 +436,7 @@ function Singletrip() {
         } catch (error) {
             console.error('Error fetching currency rates:', error);
         }
-    };    
+    };
 
     const toggleVisibility = () => {
         setIsVisible(prevState => !prevState);
@@ -455,11 +453,11 @@ function Singletrip() {
                             {/* Icon Bar Above Trip Info */}
                             <TripIconBarComponent tripId={tripId} userId={userId} isOwner={isOwner} tripData={tripData} tripLocations={tripLocations} userRole={userRole} fetchTripData={fetchTripData} />
                             {/* General Trip Info*/}
-                            <GeneralTripInfoComponent tripData={tripData} tripId={tripId} tripLocations={tripLocations} expenses={expenseUSD}/>
+                            <GeneralTripInfoComponent tripData={tripData} tripId={tripId} tripLocations={tripLocations} expenses={expenseUSD} />
                         </div>
                         <br></br>
                         <h2 style={{ textAlign: 'center', marginBottom: '20px' }}>Expenses in {homeCurrency}</h2>
-                        <SpendingCirclesComponent 
+                        <SpendingCirclesComponent
                             totalExpenses={totalExpenses}
                             homeCurrency={homeCurrency}
                             tripData={tripData}
@@ -468,8 +466,8 @@ function Singletrip() {
                         <div className='toggle-container'>
                             <div className='row justify-content-center'>
                                 <div className='col-auto'>
-                                    <div 
-                                        className='icon-div toggle-icon' 
+                                    <div
+                                        className='icon-div toggle-icon'
                                         tabIndex="0"
                                         onClick={toggleVisibility}
                                     >
@@ -489,33 +487,29 @@ function Singletrip() {
                                     </div>
                                 </div>
                             </div>
-                        
                             {isVisible && (
                                 <>
-                                <div className='row'>
-                                    {/* Budget Meter */}
-                                    <div className='col'>
-                                        <div className="meter-container"> 
-                                            <BudgetMeterComponent tripData={tripData} expenseData={expenseData} totalExpenses={totalExpenses} homeCurrency={homeCurrency}/>
+                                    <div className='row'>
+                                        {/* Budget Meter */}
+                                        <div className='col'>
+                                            <div className="meter-container">
+                                                <BudgetMeterComponent tripData={tripData} expenseData={expenseData} totalExpenses={totalExpenses} homeCurrency={homeCurrency} />
+                                            </div>
+                                        </div>
+                                        {/* Pie Chart */}
+                                        <div className='col'>
+                                            <div className="meter-container">
+                                                <CategoryDataComponent categoryData={categoryData} />
+                                            </div>
                                         </div>
                                     </div>
-                                    {/* Pie Chart */}
-                                    <div className='col'>
-                                        <div className="meter-container">
-                                            <CategoryDataComponent categoryData={categoryData} />
-                                        </div>
+                                    {/* Bar Graph */}
+                                    <div className="meter-container">
+                                        <BarGraphComponent tripData={tripData} expenseData={convertedHomeCurrencyExpenseData} categoryData={categoryData} />
                                     </div>
-                                </div>
-                                {/* Bar Graph */}
-                                <div className="meter-container">
-                                    <BarGraphComponent tripData={tripData} expenseData={convertedHomeCurrencyExpenseData} categoryData={categoryData} />
-                                </div>
-                             </>
+                                </>
                             )}
                         </div>
-                        
-                        
-                        <br></br>
                         {/* Icon Bar Above Expenses */}
                         <div>
                             <header className="icon-bar-header">
@@ -532,6 +526,7 @@ function Singletrip() {
                                         </div>
                                     </div>
                                 ) : null}
+                                <h2>Expense History</h2>
                                 {/* Filter Expenses Button */}
                                 <div className="icon-div" tooltip="Filter" tabIndex="0">
                                     <div className="icon-SVG">
@@ -558,16 +553,20 @@ function Singletrip() {
                                 )}
                             </header>
                         </div>
-                        <div className='expense-container'>
-                            {/* Expense Table */}
-                            <ExpenseTableComponent tripData={tripData} tripId={tripId} tripLocations={tripLocations} expenseData={expenseData}
-                                currencyCodes={currencyCodes} expenseCategories={expenseCategories} userRole={userRole}/>
-                        
-                            <div>
-                            {/* Exchange Rate Table */}
-                            <ExchangeRateTableComponent exchangeRates={exchangeRates} currencyCodes={currencyCodes} homeCurrency={homeCurrency}/>
+                        <div className='container'>
+                            <div className='row' style={{justifyContent: 'center', alignItems: 'center', display: 'flex', textAlign: 'center'}}>
+                                {/* Expense Table */}
+                                <ExpenseTableComponent tripData={tripData} tripId={tripId} tripLocations={tripLocations} expenseData={expenseData}
+                                    currencyCodes={currencyCodes} expenseCategories={expenseCategories} userRole={userRole} categoryData={categoryData}/>
+                            </div>
+                            <br></br>
+                            <div className='row' style={{justifyContent: 'center', alignItems: 'center', display: 'flex', textAlign: 'center', width:'50%', margin:'0 auto'}}>
+                                <h2>Exchange Rates</h2>
+                                {/* Exchange Rate Table */}
+                                <ExchangeRateTableComponent exchangeRates={exchangeRates} currencyCodes={currencyCodes} homeCurrency={homeCurrency} />
+                            </div>
+                            <br></br>
                         </div>
-                </div>
 
                     </div>
                 ) : (
@@ -622,32 +621,31 @@ function Singletrip() {
                                     >
                                         Oldest
                                     </button>
-                                    
                                     <div className="filter-option-button">
                                         <label htmlFor="category" onClick={toggleDropdown} style={{ cursor: 'pointer' }}>
                                             Select Category
                                         </label>
                                         {isDropdownVisible && (
                                             <div className="custom-dropdown">
-                                            <div className="dropdown-item" onClick={handleAllCategoriesSelect}>
-                                                All Categories
-                                            </div>
-                                            {expenseCategories.map((category) => (
-                                                <div key={category} className="dropdown-item" onClick={() => handleCategorySelect(category)}>
-                                                    {category}
+                                                <div className="dropdown-item" onClick={handleAllCategoriesSelect}>
+                                                    All Categories
                                                 </div>
-                                            ))}
-                                        </div>
+                                                {expenseCategories.map((category) => (
+                                                    <div key={category} className="dropdown-item" onClick={() => handleCategorySelect(category)}>
+                                                        {category}
+                                                    </div>
+                                                ))}
+                                            </div>
                                         )}
                                     </div>
                                 </div>
                             </div>
                         </div>
                     )}
-                </div>          
+                </div>
             </div >
             <div>
-        </div>
+            </div>
         </div >
     );
 }

--- a/client/app/singletrip/page.js
+++ b/client/app/singletrip/page.js
@@ -456,12 +456,23 @@ function Singletrip() {
                             <GeneralTripInfoComponent tripData={tripData} tripId={tripId} tripLocations={tripLocations} expenses={expenseUSD} />
                         </div>
                         <br></br>
-                        <h2 style={{ textAlign: 'center', marginBottom: '20px' }}>Expenses in {homeCurrency}</h2>
-                        <SpendingCirclesComponent
-                            totalExpenses={totalExpenses}
-                            homeCurrency={homeCurrency}
-                            tripData={tripData}
-                        />
+                        <div className='container'>
+                            <div className='row'>
+                                <div className='col' style={{flexDirection: 'column'}}>
+                                    <h2 style={{ textAlign: 'center', marginBottom: '20px' }}>Exchange Rates</h2>
+                                    {/* Exchange Rate Table */}
+                                    <ExchangeRateTableComponent exchangeRates={exchangeRates} currencyCodes={currencyCodes} homeCurrency={homeCurrency} />
+                                </div>
+                                <div className='col' style={{flexDirection: 'column'}}>
+                                    <h2 style={{ textAlign: 'center', marginBottom: '20px' }}>Expenses in {homeCurrency}</h2>
+                                    <SpendingCirclesComponent
+                                        totalExpenses={totalExpenses}
+                                        homeCurrency={homeCurrency}
+                                        tripData={tripData}
+                                    />
+                                </div>
+                            </div>
+                        </div>
                         {/* Data Visualisations Toggle */}
                         <div className='toggle-container'>
                             <div className='row justify-content-center'>
@@ -554,17 +565,13 @@ function Singletrip() {
                             </header>
                         </div>
                         <div className='container'>
-                            <div className='row' style={{justifyContent: 'center', alignItems: 'center', display: 'flex', textAlign: 'center'}}>
+                            <div className='row' style={{ justifyContent: 'center', alignItems: 'center', display: 'flex', textAlign: 'center' }}>
                                 {/* Expense Table */}
                                 <ExpenseTableComponent tripData={tripData} tripId={tripId} tripLocations={tripLocations} expenseData={expenseData}
-                                    currencyCodes={currencyCodes} expenseCategories={expenseCategories} userRole={userRole} categoryData={categoryData}/>
+                                    currencyCodes={currencyCodes} expenseCategories={expenseCategories} userRole={userRole} categoryData={categoryData} />
                             </div>
                             <br></br>
-                            <div className='row' style={{justifyContent: 'center', alignItems: 'center', display: 'flex', textAlign: 'center', width:'50%', margin:'0 auto'}}>
-                                <h2>Exchange Rates</h2>
-                                {/* Exchange Rate Table */}
-                                <ExchangeRateTableComponent exchangeRates={exchangeRates} currencyCodes={currencyCodes} homeCurrency={homeCurrency} />
-                            </div>
+                            <br></br>
                             <br></br>
                         </div>
 


### PR DESCRIPTION
## Description
- The purpose of this PR is to restyle the expense table and move the exchange rate table so that the Single Trip page is more user-friendly.
- This ticket belongs to ticket #212 
- Modified `singletrip/ExpenseTableComponent.js`, `css/ExpenseTableComponent.css`, `css/singletrip.css`, and `singletrip/page.js`

## What’s in this change?
- `singletrip/ExpenseTableComponent.js`
  - Removed the text coloring and added colored tags for each category. The color of the tags matches the colors used in the expense graphs.
  - Made the table header be sticky and green so that when the user scrolls through the table, they can always see the header.
- `css/ExpenseTableComponent.css`
  - Fixed the width of the expense table and moved CSS so that the code is more organized.
- `singletrip/page.js`
  - Moved the exchange table to be next to the spending circles.
- `css/singletrip.css`
  - Made the filter pop up be in front of the sticky header.
  - Fixed the circles width so that the circles and the exchange rate table can look nicely next to each other.
  - Centered the Select Category text


## Testing Changes
- Unit test coverage report below
- Tested different trips to check that the expense table is displaying properly.
