### PR TITLE
Update image scaling and popup styling

### DIFF
--- a/client/app/css/gallery.css
+++ b/client/app/css/gallery.css
@@ -1,26 +1,26 @@
 .gallery-grid {
     display: grid;
-    grid-template-columns: repeat(4, 1fr); /* 4 columns */
-    gap: 16px; /* Further increased gap between images */
-    padding: 20px; /* Increased padding around the grid */
+    grid-template-columns: repeat(4, 1fr);
+    gap: 16px;
+    padding: 20px;
 }
 
 .gallery-item {
     position: relative;
     overflow: hidden;
-    border-radius: 12px; /* Slightly larger rounded corners */
+    border-radius: 12px;
     width: 100%;
-    aspect-ratio: 4 / 3; /* Default aspect ratio to avoid stretching */
+    aspect-ratio: 4 / 3;
     cursor: pointer;
 }
 
 .gallery-item:nth-child(1) {
-    grid-column: span 2; /* Span two columns for a wider image */
-    aspect-ratio: 8 / 3; /* Wide rectangle */
+    grid-column: span 2;
+    aspect-ratio: 8 / 3;
 }
 
 .gallery-item:nth-child(5) {
-    grid-column: span 2; /* Span two columns */
+    grid-column: span 2;
     aspect-ratio: 8 / 3;
 }
 
@@ -32,7 +32,7 @@
     border-radius: 12px; 
 }
 
-/* Popup styling */
+/* Updated Popup styling */
 .imgPopUp {
     position: fixed;
     top: 0;
@@ -47,16 +47,29 @@
 }
 
 .imgBox {
-    max-width: 90vw;
-    max-height: 90vh;
-    overflow: hidden;
-    background: white;
-    padding: 10px;
+    position: relative;
+    background-color: white;
     border-radius: 8px;
+    padding: 10px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    overflow: hidden;
+    min-width: 200px; /* Smaller minimum to accommodate scaling */
+    min-height: 150px; /* Smaller minimum to accommodate scaling */
 }
 
 .imgBox img {
-    width: 100%;
+    max-width: 95vw;
+    max-height: 90vh;
+    min-width: 600px; /* Significantly increased for small images */
+    min-height: 450px; /* Significantly increased for small images */
+    width: auto;
     height: auto;
     object-fit: contain;
+    display: block;
+    image-rendering: -webkit-optimize-contrast;
+    image-rendering: crisp-edges;
+    transform: scale(1);
+    transition: transform 0.3s ease;
 }


### PR DESCRIPTION
## Description
- What is the purpose of this PR? Adjusting image scaling in popup to find the pop up box and scaling smaller images to be bigger for better viewing
- What ticket does this PR belong to? Ticket #227 
- Provide an overview of what files were added or changed.
modified: client/app/css/gallery.css

## What’s in this change?
- File 1 Name (gallery.css)
  - Change 1 and why it’s needed
  Fitting the image into the popup box to make sure that it doesn't cut off and extend past the popup box dimensions.  The maximum dimensions remain at 95% viewport width and 90% viewport height to ensure images still fit on screen, with improved image rendering for better quality when scaling up small images.
  
The below image was extending past the popup box dimensions, now its fixed.
![image](https://github.com/user-attachments/assets/58ba4c7d-34ca-44c0-a57c-d108e013aa89)
The below image had a very small resolution, but now its scaled up with better image rendering.
![image](https://github.com/user-attachments/assets/5b125345-8265-4881-936b-f6dd250c73ba)

## Testing Changes
- Unit test coverage report
- Explain why there is a drop in test coverage if there is any
