### PR TITLE
Add support for more image type

### DIFF
--- a/client/app/components/singletrip/UploadTripImage.js
+++ b/client/app/components/singletrip/UploadTripImage.js
@@ -2,12 +2,12 @@ import React, { useState, useEffect, useRef } from 'react';
 import axios from 'axios';
 import { ToastContainer, toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
-
+import '../../css/uploadImage.css';
 
 const TripImageComponent = ({ tripId }) => {
     const [error, setError] = useState(null);
     const fileInputRef = useRef();
-    const [uploading, setUploading] = useState(false);
+    const [isLoading, setIsLoading] = useState(false);
 
     const handleAddImageClick = () => {
         fileInputRef.current.click();
@@ -20,6 +20,8 @@ const TripImageComponent = ({ tripId }) => {
             const formData = new FormData();
             let allValidFiles = true;
 
+            setIsLoading(true); // Show loader
+
             for (const file of files) {
                 const isValid = await processFile(file, formData);
                 if (!isValid) {
@@ -30,8 +32,11 @@ const TripImageComponent = ({ tripId }) => {
             if (allValidFiles) {
                 await uploadImages(tripId, formData);
             }
+
+            setIsLoading(false); // Hide loader after upload
         }
     };
+
 
     const isValidFileType = (fileType) => {
         return fileType === 'image/png' || fileType === 'image/jpeg' || fileType === 'image/heic' || fileType === 'image/webp';
@@ -117,6 +122,13 @@ const TripImageComponent = ({ tripId }) => {
             </div>
             {/* Toast Container */}
             <ToastContainer />
+
+            {isLoading && (
+                <div className="loader">
+                    <p>Uploading images...</p>
+                    <div className="spinner"></div> {/* Add spinner animation here */}
+                </div>
+            )}
 
         </div>
     );

--- a/client/app/components/singletrip/UploadTripImage.js
+++ b/client/app/components/singletrip/UploadTripImage.js
@@ -2,7 +2,6 @@ import React, { useState, useEffect, useRef } from 'react';
 import axios from 'axios';
 import { ToastContainer, toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
-import heic2any from 'heic2any';
 
 const TripImageComponent = ({ tripId }) => {
     const [error, setError] = useState(null);
@@ -20,35 +19,18 @@ const TripImageComponent = ({ tripId }) => {
             const formData = new FormData();
             let validFiles = true;
 
-            // Process each file
-            for (const file of Array.from(files)) {
+            // Validate file types
+            Array.from(files).forEach((file) => {
                 const fileType = file.type;
-
-                // Handle HEIC files
-                if (fileType === 'image/heic' || file.name.toLowerCase().endsWith('.heic')) {
-                    try {
-                        // Convert HEIC to JPEG using heic2any
-                        const heicImage = await heic2any({ blob: file, toType: 'image/jpeg' });
-
-                        // Append the converted image to formData
-                        formData.append('images', heicImage, `${file.name.replace(/\.heic$/i, '.jpg')}`);
-                    } catch (error) {
-                        validFiles = false;
-                        toast.error(`Failed to convert HEIC image: ${file.name}.`, {
-                            autoClose: 3000,
-                        });
-                    }
-                } else if (fileType === 'image/png' || fileType === 'image/jpeg') {
-                    // If the file is PNG or JPEG, directly append it
-                    formData.append('images', file);
-                } else {
-                    // For unsupported file types
+                if (fileType !== 'image/png' && fileType !== 'image/jpeg') {
                     validFiles = false;
-                    toast.error(`Invalid file type: ${file.name}. Only PNG, JPEG, and HEIC formats are allowed.`, {
-                        autoClose: 3000,
+                    toast.error(`Invalid file type: ${file.name}. Only PNG and JPEG formats are allowed.`, {
+                        autoClose: 3000, // Toast will disappear after 3 seconds
                     });
+                } else {
+                    formData.append('images', file);
                 }
-            }
+            });
 
             if (!validFiles) {
                 return;
@@ -82,6 +64,7 @@ const TripImageComponent = ({ tripId }) => {
             }
         }
     };
+    
 
     return (
         <div>

--- a/client/app/css/uploadImage.css
+++ b/client/app/css/uploadImage.css
@@ -1,0 +1,26 @@
+.loader {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(255, 255, 255, 0.8);
+    z-index: 1000;
+}
+
+.spinner {
+    border: 4px solid #f3f3f3;
+    border-top: 4px solid #3498db;
+    border-radius: 50%;
+    width: 40px;
+    height: 40px;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -21,7 +21,6 @@
         "date-fns": "^4.1.0",
         "dayjs": "^1.11.13",
         "delayed-stream": "^1.0.0",
-        "heic2any": "^0.0.4",
         "jwt-decode": "^4.0.0",
         "leaflet": "^1.9.4",
         "lodash": "^4.17.21",
@@ -1805,11 +1804,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/heic2any": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/heic2any/-/heic2any-0.0.4.tgz",
-      "integrity": "sha512-3lLnZiDELfabVH87htnRolZ2iehX9zwpRyGNz22GKXIu0fznlblf0/ftppXKNqS26dqFSeqfIBhAmAj/uSp0cA=="
     },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -21,6 +21,7 @@
         "date-fns": "^4.1.0",
         "dayjs": "^1.11.13",
         "delayed-stream": "^1.0.0",
+        "heic2any": "^0.0.4",
         "jwt-decode": "^4.0.0",
         "leaflet": "^1.9.4",
         "lodash": "^4.17.21",
@@ -1804,6 +1805,11 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/heic2any": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/heic2any/-/heic2any-0.0.4.tgz",
+      "integrity": "sha512-3lLnZiDELfabVH87htnRolZ2iehX9zwpRyGNz22GKXIu0fznlblf0/ftppXKNqS26dqFSeqfIBhAmAj/uSp0cA=="
     },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",

--- a/client/package.json
+++ b/client/package.json
@@ -23,6 +23,7 @@
     "date-fns": "^4.1.0",
     "dayjs": "^1.11.13",
     "delayed-stream": "^1.0.0",
+    "heic2any": "^0.0.4",
     "jwt-decode": "^4.0.0",
     "leaflet": "^1.9.4",
     "lodash": "^4.17.21",

--- a/client/package.json
+++ b/client/package.json
@@ -23,7 +23,6 @@
     "date-fns": "^4.1.0",
     "dayjs": "^1.11.13",
     "delayed-stream": "^1.0.0",
-    "heic2any": "^0.0.4",
     "jwt-decode": "^4.0.0",
     "leaflet": "^1.9.4",
     "lodash": "^4.17.21",


### PR DESCRIPTION
## Description
- The purpose of this PR is to add support for heic and webp image upload.
- The PR belongs to #249 
- `client/app/components/singletrip/UploadTripImage.js` `client/app/css/uploadImage.css` 

## What’s in this change?
- `client/app/components/singletrip/UploadTripImage.js` 
  - Now able to upload heic and webp images.
  - Added a loading screen while image upload happens
  
- `client/app/css/uploadImage.css` 
  - Loading screen css

## Testing Changes
- Unit test coverage report
- Explain why there is a drop in test coverage if there is any
