### PR TITLE
Remove Homepage Whitespace

### DIFF
--- a/client/app/components/homepage/RecentTripsComponent.js
+++ b/client/app/components/homepage/RecentTripsComponent.js
@@ -79,7 +79,7 @@ const RecentTripsComponent = ({ trips }) => {
 
     return (
         <div className="recent-trips-container">
-            <h2>Recent & Upcoming</h2>
+            <h2>Recent & Upcoming Trips</h2>
             {recentTrips.map(trip => (
                 <div 
                     key={trip.trip_id} 

--- a/client/app/components/homepage/TripsDisplayComponent.js
+++ b/client/app/components/homepage/TripsDisplayComponent.js
@@ -65,10 +65,10 @@ const TripsDisplayComponent = ({ trips, userId }) => {
 
         const start = new Date(startDate);
         const end = new Date(endDate);
-        
+
         const startMonthYear = start.toLocaleDateString('en-US', options);
         const endMonthYear = end.toLocaleDateString('en-US', options);
-        
+
         if (start.getFullYear() === end.getFullYear()) {
             if (start.getMonth() === end.getMonth()) {
                 return `${startMonthYear}`; // same month
@@ -78,8 +78,8 @@ const TripsDisplayComponent = ({ trips, userId }) => {
         } else {
             return `${startMonthYear} ~ ${endMonthYear}`; // diff years
         }
-    };   
-    
+    };
+
     const handleTripClick = (tripId) => {
         window.location.href = `/singletrip?tripId=${tripId}`;
     };
@@ -100,7 +100,7 @@ const TripsDisplayComponent = ({ trips, userId }) => {
             fetchAllTripLocations();
             const initialFavorites = {};
             trips.forEach(trip => {
-                initialFavorites[trip.trip_id] = trip.favorite || false; 
+                initialFavorites[trip.trip_id] = trip.favorite || false;
             });
             setFavoritedTrips(initialFavorites);
         }
@@ -108,28 +108,33 @@ const TripsDisplayComponent = ({ trips, userId }) => {
 
     return (
         <div className="trips-display">
-            <br />
-            <h2>All Trips</h2>
-            <div className="button-container">
-                <div className="button" onClick={() => setPopUpVisible(true)}>
-                    New Trip
+            <div className="row" style={{ display: 'flex', justifyContent: 'space-between', width: '100%', marginTop:"-30px" }}>
+                <div className="col">
+                    <h1>View Your Trips:</h1>
+                </div>
+                <div className="col">
+                    <div className="button-container">
+                        <div className="button" onClick={() => setPopUpVisible(true)}>
+                            New Trip
+                        </div>
+                    </div>
                 </div>
             </div>
             <div className="search-bar">
-                <input 
-                    type="text" 
-                    placeholder="Search for a trip..." 
-                    value={searchTerm} 
-                    onChange={handleSearch} 
+                <input
+                    type="text"
+                    placeholder="Search for a trip..."
+                    value={searchTerm}
+                    onChange={handleSearch}
                     className="search-input"
                 />
             </div>
-            
+
             {isPopUpVisible && (
                 <TripFormComponent
-                    isPopUpVisible={isPopUpVisible} 
-                    setPopUpVisible={setPopUpVisible} 
-                    userId={userId} 
+                    isPopUpVisible={isPopUpVisible}
+                    setPopUpVisible={setPopUpVisible}
+                    userId={userId}
                 />
             )}
             {filteredTrips.length === 0 ? (
@@ -137,18 +142,18 @@ const TripsDisplayComponent = ({ trips, userId }) => {
             ) : (
                 <div className="trip-cards">
                     {filteredTrips.map(trip => (
-                        <Card 
-                            id={`trip-${trip.trip_id}`} 
-                            className="trips-display-card" 
-                            onClick={() => handleTripClick(trip.trip_id)} 
-                            key={trip.trip_id} 
+                        <Card
+                            id={`trip-${trip.trip_id}`}
+                            className="trips-display-card"
+                            onClick={() => handleTripClick(trip.trip_id)}
+                            key={trip.trip_id}
                             sx={{ width: 300, backgroundColor: 'var(--offwhite)' }}
                         >
                             <CardActionArea>
                                 <div className="trips-display-image-wrapper">
-                                    <DefaultTripImagesComponent 
-                                        tripId={trip.trip_id} 
-                                        tripLocations={tripLocations[trip.trip_id] || []} 
+                                    <DefaultTripImagesComponent
+                                        tripId={trip.trip_id}
+                                        tripLocations={tripLocations[trip.trip_id] || []}
                                     />
                                 </div>
                                 <CardContent>
@@ -160,15 +165,15 @@ const TripsDisplayComponent = ({ trips, userId }) => {
                                             <span key={index}>
                                                 {location}{index < tripLocations[trip.trip_id].slice(0, 3).length - 1 ? ', ' : ''}
                                             </span>
-                                        ))} 
+                                        ))}
                                     </Typography>
                                     <Typography variant="body2" sx={{ color: "text.secondary" }}>
                                         {formatTripDates(trip.start_date, trip.end_date)}
                                     </Typography>
-                                    <div 
-                                        className="favorite-icon" 
+                                    <div
+                                        className="favorite-icon"
                                         onClick={(event) => {
-                                            event.stopPropagation();  
+                                            event.stopPropagation();
                                             handleFavoriteClick(trip.trip_id);
                                         }}
                                     >
@@ -184,7 +189,7 @@ const TripsDisplayComponent = ({ trips, userId }) => {
                     ))}
                 </div>
             )}
-        </div>       
+        </div>
     );
 };
 

--- a/client/app/css/homepage.css
+++ b/client/app/css/homepage.css
@@ -11,7 +11,6 @@
     color: black;
     font-size: 21px;
     font-weight: bold;
-    margin-top: 20px;
 }
 
 .logout {

--- a/client/app/css/tripsDisplay.css
+++ b/client/app/css/tripsDisplay.css
@@ -66,7 +66,7 @@
 
 .search-bar {
     width: 100%;
-    margin-top: 20px;
+    margin-top: -20px;
     margin-bottom: 20px;
 }
 

--- a/client/app/homepage/page.js
+++ b/client/app/homepage/page.js
@@ -70,8 +70,8 @@ function homepage() {
         }
         try {
             const [tripsResponse, favoritesResponse] = await Promise.all([
-                axios.get(`${process.env.NEXT_PUBLIC_SERVER_URL}/api/trips/users/${userId}`), 
-                axios.get(`${process.env.NEXT_PUBLIC_SERVER_URL}/api/shared-trips/users/${userId}`) 
+                axios.get(`${process.env.NEXT_PUBLIC_SERVER_URL}/api/trips/users/${userId}`),
+                axios.get(`${process.env.NEXT_PUBLIC_SERVER_URL}/api/shared-trips/users/${userId}`)
             ]);
             const tripsData = tripsResponse.data.data;
             const favoritesData = favoritesResponse.data.data;
@@ -79,12 +79,12 @@ function homepage() {
                 const favorite = favoritesData.find(fav => fav.trip_id === trip.trip_id);
                 return {
                     ...trip,
-                    favorite: favorite ? favorite.favorite : false 
+                    favorite: favorite ? favorite.favorite : false
                 };
             });
-            const sortedTrips = tripsWithFavorites.sort((a, b) => b.favorite - a.favorite); 
+            const sortedTrips = tripsWithFavorites.sort((a, b) => b.favorite - a.favorite);
             setTrips(sortedTrips);
-        
+
         } catch (err) {
             console.error(err);
             setTrips([]);
@@ -123,7 +123,7 @@ function homepage() {
             console.error("Error getting all trip locations from user:", error);
             return;
         }
-    
+
         const loc_data = locations_response?.data?.data;
         if (loc_data && loc_data.length > 0) {
             const locations = loc_data.map(location => ({
@@ -136,7 +136,7 @@ function homepage() {
         } else {
             console.log("No locations available for this user.");
         }
-    };    
+    };
 
     useEffect(() => {
         handleToken();
@@ -151,35 +151,37 @@ function homepage() {
 
     return (
         <GoogleOAuthProvider clientId={googleID}>
-        <ToastContainer />
+            <ToastContainer />
             {/* Header section */}
-            <HeaderComponent 
-                headerTitle="Trip Trends" 
-                setUserName={setUserName} 
+            <HeaderComponent
+                headerTitle="Trip Trends"
+                setUserName={setUserName}
                 userId={userId}
             />
             <div className='main-container'>
                 {/* Welcome section */}
                 <div className="welcome-section">
-                    <h1>Welcome, {userName}!</h1>
-                    
-                    <br /><br />
-                    <p>See your trip history:</p>
+                    {userName ?
+                        (
+                            <h1 style={{ textAlign: "center" }}>Welcome, {userName}!</h1>
+                        ) :
+                        (
+                            <h1 style={{ textAlign: "center" }}>Welcome!</h1>
+                        )}
+                    <p>See where you've been:</p>
                 </div>
-        
+
                 <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-                    
+
                     {/* Map section */}
                     <MapComponent allTripLocations={allTripLocations} toggleTripDetails={toggleTripDetails} />
-                    
+
                     {/* Recent Trips section */}
                     <div style={{ width: '35%', marginLeft: '10px' }}>
                         <RecentTripsComponent trips={trips} />
                     </div>
-                    
-                </div>
 
-                <br /><br />
+                </div>
 
                 {/* All Trips Section */}
                 <TripsDisplayComponent trips={trips} userId={userId} />


### PR DESCRIPTION
## Description
- The purpose of this PR is to clean up the homepage by removing extra whitespace.
- This ticket belongs to ticket #263 
- Modified `homepage/RecentTripsComponent.js`, `homepage/TripsDisplayComponent.js`, `css/homepage.css`, `css/tripsDisplay.css` and `homepage/page.js`

## What’s in this change?
- `homepage/RecentTripsComponent.js`
  - Changed "Recent & Upcoming" title to say "Recent & Upcoming Trips"
- `homepage/TripsDisplayComponent.js`
  - Changed "All Trips" title to say "View Your Trips".
  - Moved the Add Trip button to be in the same row as the title and removed extra whitespace below and above them.
- `css/homepage.css`
  - Removed unnecessary margins.
- `css/tripsDisplay.css`
  - Moved the whole TripsDisplayComponent up.
- `homepage/page.js`
  - Removed extra white space.
  - Added conditional rendering so if we haven't fetched the user's username yet, we just display "Welcome!" because before it would display "Welcome, !" while we haven't received the username.
  - Replaced "See your trip history" with "See where you've been" because it makes more sense in relation to the map.

## Testing Changes
- Unit test coverage report below

## Before
<img width="1440" alt="Screen Shot 2024-11-15 at 12 29 40 PM" src="https://github.com/user-attachments/assets/aa730971-cb48-4994-889e-c5dd5c0117bf">
<img width="1440" alt="Screen Shot 2024-11-15 at 12 29 50 PM" src="https://github.com/user-attachments/assets/14c77b54-d95f-4603-ad9b-f4372d395ab9">

## After
<img width="1440" alt="Screen Shot 2024-11-15 at 12 27 52 PM" src="https://github.com/user-attachments/assets/31756565-893f-4263-b935-b7c3893315d0">
<img width="1440" alt="Screen Shot 2024-11-15 at 12 28 18 PM" src="https://github.com/user-attachments/assets/a017e380-eb94-42e3-8d2a-8ad7c6ee884f">
