### PR TITLE
Adding currency symbols + updating budget conversion

### DIFF
--- a/client/app/components/homepage/TripFormComponent.js
+++ b/client/app/components/homepage/TripFormComponent.js
@@ -5,8 +5,9 @@ import { debounce } from 'lodash';
 import '../../css/homepage.css';
 import '../../css/tripForm.css';
 import { toast } from 'react-toastify';
+import currencySymbolMap from 'currency-symbol-map';
 
-const TripFormComponent = ( {isPopUpVisible, setPopUpVisible, userId} ) => {
+const TripFormComponent = ({ isPopUpVisible, setPopUpVisible, userId, homeCurrency }) => {
     // const router = useRouter();
     const today = new Date().toISOString().split('T')[0];
     const [newTripData, setNewTripData] = useState({
@@ -32,6 +33,8 @@ const TripFormComponent = ( {isPopUpVisible, setPopUpVisible, userId} ) => {
         setTempLocation(value);
         fetchLocationSuggestions(value);
     };
+
+    const currencySymbol = currencySymbolMap(homeCurrency);
 
     const fetchLocationSuggestions = useCallback(debounce(async (query) => {
         if (query) {
@@ -182,10 +185,35 @@ const TripFormComponent = ( {isPopUpVisible, setPopUpVisible, userId} ) => {
                             </label>
                         </div>
 
-                        <label className="new-trip-field-label">
+                        <label className="new-trip-field-label" style={{ position: 'relative' }}>
                             Budget:
-                            <input type="number" name="budget" value={newTripData.budget} onChange={newTripInputChange} required />
+                            <input
+                                type="number"
+                                name="budget"
+                                value={newTripData.budget}
+                                onChange={newTripInputChange}
+                                required
+                                style={{
+                                    paddingLeft: '35px',
+                                    textAlign: 'left',
+                                }}
+                            />
+                            {/* currency symbol */}
+                            <span
+                                style={{
+                                    position: 'absolute',
+                                    left: '10px',
+                                    right: '0px',
+                                    display: 'flex',
+                                    flexWrap: 'wrap',
+                                    top: '70%',
+                                    transform: 'translateY(-50%)',
+                                }}
+                            >
+                                {currencySymbol}
+                            </span>
                         </label>
+
 
                         <label className="new-trip-field-label">
                             Locations:

--- a/client/app/components/homepage/TripsDisplayComponent.js
+++ b/client/app/components/homepage/TripsDisplayComponent.js
@@ -14,7 +14,7 @@ import DefaultTripImagesComponent from "../singletrip/DefaultTripImagesComponent
 import "../../css/tripsDisplay.css";
 import SharedUsersComponent from "../singletrip/SharedUsersComponent";
 
-const TripsDisplayComponent = ({ trips, userId }) => {
+const TripsDisplayComponent = ({ trips, userId, homeCurrency }) => {
     const [tripLocations, setTripLocations] = useState({});
     const [isPopUpVisible, setPopUpVisible] = useState(false);
     const [favoritedTrips, setFavoritedTrips] = useState({});
@@ -135,6 +135,7 @@ const TripsDisplayComponent = ({ trips, userId }) => {
                     isPopUpVisible={isPopUpVisible}
                     setPopUpVisible={setPopUpVisible}
                     userId={userId}
+                    homeCurrency={homeCurrency}
                 />
             )}
             {filteredTrips.length === 0 ? (

--- a/client/app/components/singletrip/BarGraphComponent.js
+++ b/client/app/components/singletrip/BarGraphComponent.js
@@ -1,11 +1,15 @@
+// BarGraph
 import React from 'react';
 import { BarChart } from '@mui/x-charts/BarChart';
 import dayjs from 'dayjs';
+import currencySymbolMap from 'currency-symbol-map';
 
-const BarGraphComponent = ({ tripData, expensesToDisplay, categoryData }) => {
+const BarGraphComponent = ({ tripData, expensesToDisplay, categoryData, currency }) => {
     if (!tripData || !expensesToDisplay || !categoryData || expensesToDisplay.length === 0 || categoryData.labels.length === 0) {
         return <div>No expense data available to display....</div>;
     }
+
+    const currencySymbol = currencySymbolMap(currency);
 
     const formatDate = (dateStr) => {
         const [year, month, day] = dateStr.split('-');
@@ -74,7 +78,8 @@ const BarGraphComponent = ({ tripData, expensesToDisplay, categoryData }) => {
 
         sortedDates.forEach(date => {
             const amount = expensesByCategory[date]?.[category] || 0;
-            categoryDataPoints.push(amount);
+            // categoryDataPoints.push(`${currencySymbol}${amount.toFixed(2)}`);
+            categoryDataPoints.push(amount.toFixed(2));
         });
 
         return {
@@ -84,10 +89,7 @@ const BarGraphComponent = ({ tripData, expensesToDisplay, categoryData }) => {
             stack: categoryStackMap[category],
         };
     });
-
-    // console.log("EBC: ", expensesByCategory)
-    // console.log("Series: ", series)
-
+    
     return (
         <div>
             <h3 style={{ textAlign: "center" }}>Daily Expenses by Category</h3>

--- a/client/app/components/singletrip/BudgetMeterComponent.js
+++ b/client/app/components/singletrip/BudgetMeterComponent.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactSpeedometer, { Transition } from 'react-d3-speedometer';
 import currencySymbolMap from 'currency-symbol-map';
 
-const BudgetMeterComponent = ({ tripData, expensesToDisplay, totalExpenses, currency}) => {
+const BudgetMeterComponent = ({ tripData, convertedBudget, expensesToDisplay, totalExpenses, currency}) => {
     const currencySymbol = currencySymbolMap(currency);
 
     return(
@@ -10,7 +10,7 @@ const BudgetMeterComponent = ({ tripData, expensesToDisplay, totalExpenses, curr
             <p id='budgetTitle'> Budget Meter</p>
             {expensesToDisplay && totalExpenses === 0 ? (
                 <p>Loading your budget data...</p>
-            ) : totalExpenses > tripData.data.budget ? (
+            ) : totalExpenses > convertedBudget ? (
                 <div style={{
                     marginTop: "10px",
                     width: "350px",
@@ -20,8 +20,8 @@ const BudgetMeterComponent = ({ tripData, expensesToDisplay, totalExpenses, curr
                     <ReactSpeedometer
                         width={300}
                         minValue={0}
-                        maxValue={tripData.data.budget}
-                        value={tripData.data.budget}
+                        maxValue={convertedBudget}
+                        value={convertedBudget.toFixed(2)}
                         needleColor="steelblue"
                         needleTransitionDuration={2500}
                         needleTransition={Transition.easeBounceOut}
@@ -39,7 +39,7 @@ const BudgetMeterComponent = ({ tripData, expensesToDisplay, totalExpenses, curr
                     <ReactSpeedometer
                         width={300}
                         minValue={0}
-                        maxValue={tripData.data.budget}
+                        maxValue={convertedBudget}
                         value={totalExpenses.toFixed(2)}
                         needleColor="steelblue"
                         needleTransitionDuration={2500}
@@ -53,7 +53,7 @@ const BudgetMeterComponent = ({ tripData, expensesToDisplay, totalExpenses, curr
                 <p>Loading your budget data...</p>
             ) : (
                 <div style={{ textAlign: 'center', margin: '20px 0' }}>
-                    {totalExpenses > tripData.data.budget ? (
+                    {totalExpenses > convertedBudget ? (
                         <p 
                             id='budget-text' 
                             style={{
@@ -69,7 +69,7 @@ const BudgetMeterComponent = ({ tripData, expensesToDisplay, totalExpenses, curr
                                 boxShadow: '0 4px 8px rgba(0,0,0,0.2)',
                             }}
                         >
-                            <strong>{currencySymbol}{(totalExpenses - tripData.data.budget).toFixed(2)}</strong> over budget!
+                            <strong>{currencySymbol}{(totalExpenses - convertedBudget).toFixed(2)}</strong> over budget!
                         </p>
                     ) : (
                         <p 

--- a/client/app/components/singletrip/BudgetMeterComponent.js
+++ b/client/app/components/singletrip/BudgetMeterComponent.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import ReactSpeedometer, { Transition } from 'react-d3-speedometer';
+import currencySymbolMap from 'currency-symbol-map';
 
 const BudgetMeterComponent = ({ tripData, expensesToDisplay, totalExpenses, currency}) => {
+    const currencySymbol = currencySymbolMap(currency);
+
     return(
         <div>
             <p id='budgetTitle'> Budget Meter</p>
@@ -66,7 +69,7 @@ const BudgetMeterComponent = ({ tripData, expensesToDisplay, totalExpenses, curr
                                 boxShadow: '0 4px 8px rgba(0,0,0,0.2)',
                             }}
                         >
-                            <strong>${(totalExpenses - tripData.data.budget).toFixed(2)}</strong> over budget!
+                            <strong>{currencySymbol}{(totalExpenses - tripData.data.budget).toFixed(2)}</strong> over budget!
                         </p>
                     ) : (
                         <p 

--- a/client/app/components/singletrip/CategoryDataComponent.js
+++ b/client/app/components/singletrip/CategoryDataComponent.js
@@ -1,13 +1,34 @@
 import React from 'react';
 import { Pie } from 'react-chartjs-2';
+import { Chart as ChartJS, Tooltip, Legend, ArcElement } from 'chart.js';
+import currencySymbolMap from 'currency-symbol-map';
 
-const CategoryDataComponent = ({ categoryData }) => {
+// Register Chart.js components
+ChartJS.register(Tooltip, Legend, ArcElement);
+
+const CategoryDataComponent = ({ categoryData, currency }) => {
+    const currencySymbol = currencySymbolMap(currency);
+
+    const options = {
+        plugins: {
+            tooltip: {
+                callbacks: {
+                    label: (context) => {
+                        const label = ` Total in ${currency}` || '';
+                        const value = context.raw || '';
+                        return `${label}: ${currencySymbol}${value}`;
+                    },
+                },
+            },
+        },
+    };
+
     return (
         <div>
-             <p id='expenseTitle'>Expenses by Category</p>
+            <p id="expenseTitle">Expenses by Category</p>
             {categoryData && categoryData.datasets && categoryData.datasets.length > 0 ? (
                 <div className="pie-chart-container">
-                    <Pie data={categoryData} />
+                    <Pie data={categoryData} options={options} />
                 </div>
             ) : (
                 <p>No expense data available to display.</p>

--- a/client/app/components/singletrip/CurrencyToggleComponent.js
+++ b/client/app/components/singletrip/CurrencyToggleComponent.js
@@ -1,3 +1,4 @@
+// CurrencyToggle
 import React, { useState, useEffect } from "react";
 import Switch from "react-switch";
 
@@ -24,14 +25,15 @@ const CurrencyToggleComponent = ({ homeCurrency, otherCurrencies, toggleChange }
 
   return (
     <div
-      style={{
+    style={{
+        position: "absolute",
+        right: "45px",
         display: "flex",
-        justifyContent: "flex-end",
-        alignItems: "flex-start",
-        padding: "10px",
-        width: "100%",
-        marginRight: "20px"
-      }}
+        gap: "5px",
+        padding: "0px", 
+        flexWrap: "wrap",
+        marginTop: "15px",
+    }}
     >
       {allCurrencies.map((currency) => (
         <div

--- a/client/app/components/singletrip/ExpenseFormComponent.js
+++ b/client/app/components/singletrip/ExpenseFormComponent.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import ReceiptImageComponent from './ReceiptImageComponent';
+import currencySymbolMap from 'currency-symbol-map';
 
 const ExpenseFormComponent = ({ 
     tripId, 
@@ -42,6 +43,8 @@ const ExpenseFormComponent = ({
         setIsUploadHidden(newState);
     };
 
+    const currencySymbol = currencySymbolMap(selectedCurrency);
+
     return (
         <div className="expense-form">
             {isPopUpVisible && (
@@ -65,16 +68,35 @@ const ExpenseFormComponent = ({
                                 </label>
 
                                 <div className="field-pair">
-                                    <label className="new-expense-field-label half-width">
-                                        Amount:
-                                        <input
-                                            type="number"
-                                            name="amount"
-                                            value={newExpenseData.amount}
-                                            onChange={newExpenseInputChange}
-                                            required
-                                        />
+                                <label className="new-expense-field-label half-width" style={{ position: 'relative' }}>
+                                    Amount:
+                                    <input
+                                        type="number"
+                                        name="amount"
+                                        value={newExpenseData.amount}
+                                        onChange={newExpenseInputChange}
+                                        required
+                                        style={{
+                                            paddingLeft: '35px',
+                                            paddingRight: '10px',
+                                            width: '100%',
+                                            textAlign: 'left',
+                                        }}
+                                    />
+                                    {/* currency symbol */}
+                                    <span
+                                        style={{
+                                            position: 'absolute',
+                                            left: '15px',
+                                            top: '70%',
+                                            transform: 'translateY(-50%)',
+                                            pointerEvents: 'none',
+                                        }}
+                                    >
+                                        {currencySymbol}
+                                    </span>
                                     </label>
+
                                     <label className="new-expense-field-label half-width">
                                         Currency:
                                         <select

--- a/client/app/components/singletrip/ExpenseTableComponent.js
+++ b/client/app/components/singletrip/ExpenseTableComponent.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import Table from 'react-bootstrap/Table';
 import '../../css/ExpenseTableComponent.css';
+import currencySymbolMap from 'currency-symbol-map';
 
 const ExpenseTableComponent = ({ tripData, tripId, tripLocations, expensesToDisplay, currencyCodes, expenseCategories, categoryData }) => {
     const [isEditPopupVisible, setEditPopupVisible] = useState(false);
@@ -88,11 +89,11 @@ const ExpenseTableComponent = ({ tripData, tripId, tripLocations, expensesToDisp
                                 {expensesToDisplay.map((expense) => {
                                     const categoryIndex = categoryData.labels.indexOf(expense.category);
                                     const tagColor = categoryData.datasets[0].backgroundColor[categoryIndex];
-
+                                    const currencySymbol = currencySymbolMap(expense.currency);
                                     return (
                                         <tr key={expense.expense_id}>
                                             <td>{expense.name}</td>
-                                            <td>{expense.amount}</td>
+                                            <td>{currencySymbol}{expense.amount}</td>
                                             <td>{expense.currency}</td>
                                             <td>
                                                 {/* Category with color tag */}
@@ -156,7 +157,25 @@ const ExpenseTableComponent = ({ tripData, tripId, tripLocations, expensesToDisp
                                                                                 value={selectedExpense.amount}
                                                                                 onChange={handleEditChange}
                                                                                 required
+                                                                                style={{
+                                                                                    paddingLeft: '35px',
+                                                                                    paddingRight: '10px',
+                                                                                    width: '100%',
+                                                                                    textAlign: 'left',
+                                                                                }}
                                                                             />
+                                                                            {/* currency symbol */}
+                                                                            <span
+                                                                                style={{
+                                                                                    position: 'absolute',
+                                                                                    left: '35px',
+                                                                                    top: '41.2%',
+                                                                                    transform: 'translateY(-50%)',
+                                                                                    pointerEvents: 'none',
+                                                                                }}
+                                                                            >
+                                                                                {currencySymbol}
+                                                                            </span>
                                                                         </label>
                                                                         <label className="edit-expense-field-label">
                                                                             Currency:

--- a/client/app/components/singletrip/GeneralTripInfoComponent.js
+++ b/client/app/components/singletrip/GeneralTripInfoComponent.js
@@ -9,7 +9,7 @@ import StarBorderIcon from '@mui/icons-material/StarBorder';
 import currencySymbolMap from 'currency-symbol-map';
 import '../../css/singletrip.css';
 
-const GeneralTripInfoComponent = ({ tripData, tripId, tripLocations, expenses, totalExpenses, currency }) => {
+const GeneralTripInfoComponent = ({ tripData, convertedBudget, tripId, tripLocations, expenses, totalExpenses, currency }) => {
     const [totalExpensesByDate, setTotalExpensesByDate] = useState({});
     const [selectedDate, setSelectedDate] = useState(null);
     const [showExpenseBox, setShowExpenseBox] = useState(false);
@@ -17,7 +17,8 @@ const GeneralTripInfoComponent = ({ tripData, tripId, tripLocations, expenses, t
     const [isFavorited, setIsFavorited] = useState(false);
     const expenseBoxRef = useRef(null);
     const currencySymbol = currencySymbolMap(currency);
-    const exceedsBudget = totalExpenses > tripData.data.budget;
+    const exceedsBudget = totalExpenses > convertedBudget;
+    console.log(convertedBudget);
 
     const DateComponent = ({ dateStr, showYear }) => {
         const [year, month, day] = dateStr.split('-');
@@ -154,9 +155,9 @@ const GeneralTripInfoComponent = ({ tripData, tripId, tripLocations, expenses, t
                 </div>
 
                 <div className="trip-overview-div">
-                    <div className="trip-overview-circle">💰</div>
+                    <div className="trip-overview-circle" style={{marginLeft: '-30px'}}>💰</div>
                     <div className="trip-overview-content">
-                        <p>{currencySymbol}{tripData.data.budget}</p>
+                        <p style={{marginLeft: '-30px'}}>{currencySymbol}{convertedBudget}</p>
                     </div>
                 </div>
 

--- a/client/app/components/singletrip/GeneralTripInfoComponent.js
+++ b/client/app/components/singletrip/GeneralTripInfoComponent.js
@@ -1,3 +1,4 @@
+//GeneralTripInfo
 import React, { useEffect, useState, useRef } from 'react';
 import Calendar from 'react-calendar';
 import { parseISO, startOfDay, endOfDay } from 'date-fns';
@@ -5,20 +6,26 @@ import LocationsDropdownComponent from '../singletrip/LocationsDropdownComponent
 import DefaultTripImagesComponent from '../singletrip/DefaultTripImagesComponent';
 import StarIcon from '@mui/icons-material/Star';
 import StarBorderIcon from '@mui/icons-material/StarBorder';
+import currencySymbolMap from 'currency-symbol-map';
 import '../../css/singletrip.css';
 
-const GeneralTripInfoComponent = ({ tripData, tripId, tripLocations, expenses }) => {
+const GeneralTripInfoComponent = ({ tripData, tripId, tripLocations, expenses, totalExpenses, currency }) => {
     const [totalExpensesByDate, setTotalExpensesByDate] = useState({});
     const [selectedDate, setSelectedDate] = useState(null);
     const [showExpenseBox, setShowExpenseBox] = useState(false);
     const [boxPosition, setBoxPosition] = useState({ top: 0, left: 0 });
     const [isFavorited, setIsFavorited] = useState(false);
     const expenseBoxRef = useRef(null);
+    const currencySymbol = currencySymbolMap(currency);
+    const exceedsBudget = totalExpenses > tripData.data.budget;
 
-
-    const DateComponent = ({ dateStr }) => {
+    const DateComponent = ({ dateStr, showYear }) => {
         const [year, month, day] = dateStr.split('-');
-        const formattedDate = new Intl.DateTimeFormat('en-US', { month: 'long', day: 'numeric', year: 'numeric'}).format(
+        const options = showYear
+            ? { month: 'long', day: 'numeric', year: 'numeric' }
+            : { month: 'long', day: 'numeric' };
+    
+        const formattedDate = new Intl.DateTimeFormat('en-US', options).format(
             new Date(year, month - 1, day)
         );
     
@@ -39,11 +46,14 @@ const GeneralTripInfoComponent = ({ tripData, tripId, tripLocations, expenses })
         
         const startDate = startOfDay(parseISO(tripData.data.start_date));
         const endDate = endOfDay(parseISO(tripData.data.end_date));
+        const startYear = tripData.data.start_date.split('-')[0];
+        const endYear = tripData.data.end_date.split('-')[0];
+        const showYear = startYear !== endYear;
 
-        return { startDate, endDate };
+        return { startDate, endDate, startYear, endYear, showYear };
     };
 
-    const { startDate, endDate } = getTripDates();
+    const { startDate, endDate, startYear, endYear, showYear } = getTripDates();
 
     useEffect(() => {
         if (!expenses || !Array.isArray(expenses)) return; // to handle expenses undefined during runtime
@@ -116,7 +126,7 @@ const GeneralTripInfoComponent = ({ tripData, tripId, tripLocations, expenses })
         <div>
             <br/>
             <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: '20px' }}>
-                <h2 style={{ marginRight: '10px' }}>Trip Info</h2>
+                <h2 style={{ marginRight: '10px', marginTop: '20px'}}>Trip Info</h2>
                 {/* Favorite Star Icon */}
                 <div 
                     className="favorite-icon" 
@@ -137,8 +147,8 @@ const GeneralTripInfoComponent = ({ tripData, tripId, tripLocations, expenses })
                     <div className="trip-overview-circle">🗓️</div>
                     <div className="trip-overview-content">
                         <p>
-                            <DateComponent dateStr={tripData.data.start_date} /> {' ~ '} 
-                            <DateComponent dateStr={tripData.data.end_date} />
+                            <DateComponent dateStr={tripData.data.start_date} showYear={showYear} /> {' ~ '}
+                            <DateComponent dateStr={tripData.data.end_date} showYear={true} />
                         </p>
                     </div>
                 </div>
@@ -146,7 +156,7 @@ const GeneralTripInfoComponent = ({ tripData, tripId, tripLocations, expenses })
                 <div className="trip-overview-div">
                     <div className="trip-overview-circle">💰</div>
                     <div className="trip-overview-content">
-                        <p>{tripData.data.budget}</p>
+                        <p>{currencySymbol}{tripData.data.budget}</p>
                     </div>
                 </div>
 
@@ -184,7 +194,7 @@ const GeneralTripInfoComponent = ({ tripData, tripId, tripLocations, expenses })
                                     onClick={(event) => handleDateClick(date, event)}
                                 >
                                     {total !== undefined && (
-                                        <div className="expense-amount">{total.toFixed(2)}</div>
+                                        <div className={`expense-amount ${exceedsBudget ? 'cal-above-budget' : 'cal-below-budget'}`}>{currencySymbol}{total.toFixed(2)}</div>
                                     )}
                                 </div>
                             );
@@ -211,7 +221,7 @@ const GeneralTripInfoComponent = ({ tripData, tripId, tripLocations, expenses })
                                 {selectedDate.expenses.map((expense, index) => (
                                     <li key={index} style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '5px' }}>
                                         <span style={{ flex: 1 }}>{expense.name}</span>
-                                        <span style={{ width: '80px', textAlign: 'right' }}>{expense.amount}</span> {/* Fixed width for amount */}
+                                        <span style={{ width: '80px', textAlign: 'right' }}>{currencySymbol}{expense.amount}</span> {/* Fixed width for amount */}
                                     </li>
                                 ))}
                             </ul>

--- a/client/app/components/singletrip/SpendingCirclesComponent.js
+++ b/client/app/components/singletrip/SpendingCirclesComponent.js
@@ -1,6 +1,7 @@
 import React from 'react';
+import currencySymbolMap from 'currency-symbol-map';
 
-const SpendingCirclesComponent = ({ totalExpenses, tripData }) => {
+const SpendingCirclesComponent = ({ totalExpenses, tripData, currency }) => {
     const startDate = new Date(tripData.data.start_date);
     const endDate = new Date(tripData.data.end_date);
     const totalDays = Math.ceil((endDate - startDate) / (1000 * 60 * 60 * 24)) + 1;
@@ -9,19 +10,20 @@ const SpendingCirclesComponent = ({ totalExpenses, tripData }) => {
     const remainingDays = Math.ceil((endDate - new Date()) / (1000 * 60 * 60 * 24));
     const forecastedSpending = remainingDays > 0 ? (avgDailySpending * remainingDays).toFixed(2) : 0;
     const exceedsBudget = totalExpenses > tripData.data.budget;
+    const currencySymbol = currencySymbolMap(currency);
 
     return (
         <div className="spending-circles-container">
             <div className="circle-card">
-                <div className="circle-card-spending">{avgDailySpending}</div>
+                <div className="circle-card-spending">{currencySymbol}{avgDailySpending}</div>
                 <p>Avg. Daily Spending</p>
             </div>
             <div className={`circle-card ${exceedsBudget ? 'above-budget' : 'below-budget'}`}>
-                <div className="circle-card-spending">{totalSpending}</div>
+                <div className="circle-card-spending">{currencySymbol}{totalSpending}</div>
                 <p>Total Spending</p>
             </div>
             <div className="circle-card">
-                <div className="circle-card-spending">{forecastedSpending}</div>
+                <div className="circle-card-spending">{currencySymbol}{forecastedSpending}</div>
                 <p>Forecasted Spending</p>
             </div>
         </div>

--- a/client/app/components/singletrip/SpendingCirclesComponent.js
+++ b/client/app/components/singletrip/SpendingCirclesComponent.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import currencySymbolMap from 'currency-symbol-map';
 
-const SpendingCirclesComponent = ({ totalExpenses, tripData, currency }) => {
+const SpendingCirclesComponent = ({ totalExpenses, tripData, convertedBudget, currency }) => {
     const startDate = new Date(tripData.data.start_date);
     const endDate = new Date(tripData.data.end_date);
     const totalDays = Math.ceil((endDate - startDate) / (1000 * 60 * 60 * 24)) + 1;
@@ -9,7 +9,7 @@ const SpendingCirclesComponent = ({ totalExpenses, tripData, currency }) => {
     const totalSpending = totalExpenses.toFixed(2);
     const remainingDays = Math.ceil((endDate - new Date()) / (1000 * 60 * 60 * 24));
     const forecastedSpending = remainingDays > 0 ? (avgDailySpending * remainingDays).toFixed(2) : 0;
-    const exceedsBudget = totalExpenses > tripData.data.budget;
+    const exceedsBudget = totalExpenses > convertedBudget;
     const currencySymbol = currencySymbolMap(currency);
 
     return (

--- a/client/app/css/singletrip.css
+++ b/client/app/css/singletrip.css
@@ -347,7 +347,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    z-index: 2;
+    z-index: 1000;
 }
 
 .filter-popup-content {

--- a/client/app/css/singletrip.css
+++ b/client/app/css/singletrip.css
@@ -283,7 +283,15 @@
 
 .expense-amount {
     font-size: 0.9em; 
-    color: rgb(243, 133, 133); 
+    /* color: rgb(243, 133, 133);  */
+}
+
+.cal-below-budget {
+    color: var(--lightergreen);
+}
+
+.cal-above-budget {
+    color: rgb(243, 133, 133);
 }
 
 #tripName {
@@ -908,7 +916,6 @@
 
 .favorite-icon {
     cursor: pointer;
-
     display: flex;
     align-items: center;
     justify-content: center;
@@ -919,6 +926,7 @@
     background-color: rgba(123, 117, 117, 0.223);  
     z-index: 3; 
     transition: background-color 0.3s ease, border-color 0.3s ease;
+    margin-top: 9px;
 }
 
 .favorite-icon:hover {

--- a/client/app/globals.css
+++ b/client/app/globals.css
@@ -5,6 +5,7 @@
   --darkgreen: #344E41;
   --lightergreen: #A3B18A;
   --lightgreen: #588157;
+  --mediumgreen: #60945fc9;
   --offwhite: #DAD7CD;
 }
 
@@ -185,6 +186,36 @@ button {
   width: 100%;
   text-align: center;
   padding-bottom: 30px;
+}
+
+@media (max-width: 805px) {
+  .modal-content {
+    max-width: 70% !important;
+  }
+}
+
+@media (max-width: 1150px) {
+  .modal-content {
+    max-width: 50% !important;
+  }
+}
+
+@media (max-width: 700px) {
+  .modal-content {
+    max-width: 73% !important;
+  }
+}
+
+@media (max-width: 420px) {
+  .modal-content {
+    max-width: 80% !important;
+  }
+}
+
+@media (max-width: 390px) {
+  .modal-content {
+    max-width: 87% !important;
+  }
 }
 
 form {

--- a/client/app/homepage/page.js
+++ b/client/app/homepage/page.js
@@ -21,6 +21,7 @@ function homepage() {
     const [trips, setTrips] = useState([]);
     const [allTripLocations, setAllTripLocations] = useState([]);
     const [userId, setUserId] = useState(null);
+    const [homeCurrency, setHomeCurrency] = useState(null);
 
     // Used to display user's name
     const fetchUserName = async () => {
@@ -56,6 +57,30 @@ function homepage() {
             console.error("User ID not found.");
         }
     }
+
+    const fetchHomeCurrency = async (userId) => {
+        try {
+            const response = await axios.get(`${process.env.NEXT_PUBLIC_SERVER_URL}/api/users/${userId}/home-currency`);
+            return response.data.home_currency;
+        } catch (error) {
+            console.error('Error fetching home currency:', error);
+            return null; // Handle error as needed
+        }
+    };
+
+    // Fetch home currency when userId changes
+    useEffect(() => {
+        const getHomeCurrency = async () => {
+            if (userId) {
+                const currency = await fetchHomeCurrency(userId);
+                if (currency) {
+                    setHomeCurrency(currency);  // Only set if currency is valid
+                }
+            }
+        };
+
+        getHomeCurrency(); // Fetch home currency when userId is available
+    }, [userId]);
 
     useEffect(() => {
         fetchUserName();
@@ -184,7 +209,7 @@ function homepage() {
                 </div>
 
                 {/* All Trips Section */}
-                <TripsDisplayComponent trips={trips} userId={userId} />
+                <TripsDisplayComponent trips={trips} userId={userId} homeCurrency={homeCurrency}/>
 
             </div>
         </GoogleOAuthProvider>

--- a/client/app/singletrip/page.js
+++ b/client/app/singletrip/page.js
@@ -426,12 +426,14 @@ function Singletrip() {
     
             setConvertedExpenses(convertedData);
             setTotalExpenses(totalExpensesInTargetCurrency);
-    
+
+            let currency = selectedToggleCurrency !== "" ? selectedToggleCurrency : homeCurrency;
+
             // prepare data for pie chart
             setCategoryData({
                 labels: Object.keys(categoryTotals),
                 datasets: [{
-                    label: `Expenses by Category in ${targetCurrency}`,
+                    label: ` Total in ${currency}`,
                     data: Object.values(categoryTotals),
                     backgroundColor: [
                         '#2A9D8F', '#e76f51', '#E9C46A', '#F4A261', '#c476bf', '#264653', '#e5989b', '#9d0208', '#e4c1f9',
@@ -474,10 +476,26 @@ function Singletrip() {
                     <div>
                         <div className='container'>
                             {/* Icon Bar Above Trip Info */}
-                            <TripIconBarComponent tripId={tripId} userId={userId} isOwner={isOwner} tripData={tripData} tripLocations={tripLocations} userRole={userRole} fetchTripData={fetchTripData} />
-                            <CurrencyToggleComponent homeCurrency={homeCurrency} otherCurrencies={otherCurrencies} toggleChange={handleCurrencyToggleChange} />
+                            <TripIconBarComponent 
+                                tripId={tripId} 
+                                userId={userId} 
+                                isOwner={isOwner} 
+                                tripData={tripData} 
+                                tripLocations={tripLocations} 
+                                userRole={userRole} 
+                                fetchTripData={fetchTripData} />
+                            <CurrencyToggleComponent 
+                                homeCurrency={homeCurrency} 
+                                otherCurrencies={otherCurrencies} 
+                                toggleChange={handleCurrencyToggleChange} />
                             {/* General Trip Info*/}
-                            <GeneralTripInfoComponent tripData={tripData} tripId={tripId} tripLocations={tripLocations} expenses={expensesToDisplay} />
+                            <GeneralTripInfoComponent 
+                                tripData={tripData} 
+                                tripId={tripId} 
+                                tripLocations={tripLocations} 
+                                expenses={expensesToDisplay} 
+                                totalExpenses={selectedToggleCurrency !== "" ? totalExpensesInToggleCurrency : totalExpenses}
+                                currency={selectedToggleCurrency !== "" ? selectedToggleCurrency : homeCurrency} />
                         </div>
                         <br></br>
                         <div className='container'>
@@ -485,7 +503,10 @@ function Singletrip() {
                                 <div className='col' style={{flexDirection: 'column'}}>
                                     <h2 style={{ textAlign: 'center', marginBottom: '20px', marginTop: '15px'}}>Exchange Rates</h2>
                                     {/* Exchange Rate Table */}
-                                    <ExchangeRateTableComponent exchangeRates={exchangeRates} currencyCodes={currencyCodes} homeCurrency={homeCurrency} />
+                                    <ExchangeRateTableComponent 
+                                        exchangeRates={exchangeRates} 
+                                        currencyCodes={currencyCodes} 
+                                        homeCurrency={homeCurrency} />
                                 </div>
                                 <div className='col' style={{flexDirection: 'column'}}>
                                 <h2 style={{ textAlign: 'center', marginTop: '30px', marginBottom: '20px' }}>
@@ -494,6 +515,7 @@ function Singletrip() {
                                     <SpendingCirclesComponent
                                         totalExpenses={selectedToggleCurrency !== "" ? totalExpensesInToggleCurrency : totalExpenses}
                                         tripData={tripData}
+                                        currency={selectedToggleCurrency !== "" ? selectedToggleCurrency : homeCurrency}
                                     />
                                 </div>
                             </div>
@@ -540,7 +562,8 @@ function Singletrip() {
                                         <div className='col'>
                                             <div className="meter-container">
                                                 <CategoryDataComponent 
-                                                    categoryData={categoryData} />
+                                                    categoryData={categoryData} 
+                                                    currency={selectedToggleCurrency !== "" ? selectedToggleCurrency : homeCurrency} />
                                             </div>
                                         </div>
                                     </div>
@@ -549,7 +572,8 @@ function Singletrip() {
                                         <BarGraphComponent 
                                             tripData={tripData} 
                                             expensesToDisplay={selectedToggleCurrency !== "" ? expensesToDisplay : convertedHomeCurrencyExpenseData}
-                                            categoryData={categoryData} />
+                                            categoryData={categoryData}
+                                            currency={selectedToggleCurrency !== "" ? selectedToggleCurrency : homeCurrency} />
                                     </div>
                                 </>
                             )}

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -18,6 +18,7 @@
         "axios": "^1.7.7",
         "bootstrap": "^5.3.3",
         "chart.js": "^4.4.4",
+        "currency-symbol-map": "^5.1.0",
         "date-fns": "^4.1.0",
         "dayjs": "^1.11.13",
         "delayed-stream": "^1.0.0",
@@ -1393,6 +1394,11 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
+    },
+    "node_modules/currency-symbol-map": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/currency-symbol-map/-/currency-symbol-map-5.1.0.tgz",
+      "integrity": "sha512-LO/lzYRw134LMDVnLyAf1dHE5tyO6axEFkR3TXjQIOmMkAM9YL6QsiUwuXzZAmFnuDJcs4hayOgyIYtViXFrLw=="
     },
     "node_modules/d3-array": {
       "version": "3.2.4",

--- a/client/package.json
+++ b/client/package.json
@@ -20,6 +20,7 @@
     "axios": "^1.7.7",
     "bootstrap": "^5.3.3",
     "chart.js": "^4.4.4",
+    "currency-symbol-map": "^5.1.0",
     "date-fns": "^4.1.0",
     "dayjs": "^1.11.13",
     "delayed-stream": "^1.0.0",


### PR DESCRIPTION
## Description
- The purpose of this PR is to add currency symbols wherever possible, and budget is now converted to the selected currency.
- This PR belongs to ticket #255 and #170 
- Single trip view components, page.js files, and css files.

## What’s in this change?
- TripFormComponent, ExpenseFormComponent
  - Added the currency symbol of homeCurrency in the input field.
  - When selected currency get updated in the form, the currency symbol also updates.
- BarGraphComponent, BudgetMeterComponent, CategoryDataComponent, SpendingCirclesComponent, ExpenseTableComponent, GeneralTripInfoComponent
  - Added currency symbols where needed: hovering over a pie chart slice, total spending circles, etc, each expense in the 
  - Note: was not able to add symbols to the budget meter due to the setup.
  - SpendingCircles, BarGraph, and GeneralTripInfo now take the converted budget into account rather than the static amount.
- Design changes include dynamically displaying the year of in the trip info section. (If it's the same year, the year is displayed once, otherwise, both years are displayed) done to reduce redundancy.
- Calendar expenses follow the budget on the color being displayed to match the totalSpending circle.
- Responsive added to the modal forms in the globals css file so when shrinked, the currency symbol stays in the same position.

Converted budget change:
BEFORE the budget wouldn't change.
<img width="983" alt="Screenshot 2024-11-18 at 5 43 38 PM" src="https://github.com/user-attachments/assets/6d1061ef-9262-4184-9bc6-eca481f152ba">


AFTER
<img width="1048" alt="Screenshot 2024-11-18 at 5 37 54 PM" src="https://github.com/user-attachments/assets/77230532-c055-4398-a4c9-afdade2fa10b">

Few examples of currency symbols added:
<img width="623" alt="Screenshot 2024-11-18 at 5 38 32 PM" src="https://github.com/user-attachments/assets/73fdc99c-e935-4593-8ec7-9817a3d4d585">
<img width="709" alt="Screenshot 2024-11-18 at 5 38 57 PM" src="https://github.com/user-attachments/assets/b15e54da-56d1-4387-ac25-a42d5160675c">
<img width="207" alt="Screenshot 2024-11-18 at 5 39 18 PM" src="https://github.com/user-attachments/assets/f55772a8-49f4-4ea7-a6de-3c73aa0481db">
<img width="769" alt="Screenshot 2024-11-18 at 5 39 41 PM" src="https://github.com/user-attachments/assets/688f4308-07fe-4428-ace2-b6e571eda0b0">



## Testing Changes
- No new testing. Frontend changes only.
