### PR TITLE
Merge dev to main (loading screens + bugs)

### DIFF
--- a/client/app/components/homepage/MapComponent.js
+++ b/client/app/components/homepage/MapComponent.js
@@ -153,7 +153,7 @@ const MapComponent = ({ allTripLocations, toggleTripDetails }) => {
         }
     }, [allTripLocations, toggleTripDetails]); // rerenders when trip locations are updated
 
-    return <div ref={mapRef} style={{ height: '537px', width: '70%' }}></div>;
+    return <div ref={mapRef} style={{ height: '537px', width: '85%' }}></div>;
 };
 
 export default MapComponent;

--- a/client/app/components/homepage/RecentTripsComponent.js
+++ b/client/app/components/homepage/RecentTripsComponent.js
@@ -17,8 +17,13 @@ const RecentTripsComponent = ({ trips }) => {
             new Date(year, month - 1, day)
         );
     
-        return <span>{formattedDate}</span>;
+        const parts = formattedDate.split(' ');
+        const abbreviatedMonth = parts[0].slice(0, 3);
+        const restOfDate = parts.slice(1).join(' ');
+    
+        return <span>{`${abbreviatedMonth} ${restOfDate}`}</span>;
     };
+    
 
     useEffect(() => {
         // Function to find the three most recent trips

--- a/client/app/components/singletrip/BarGraphComponent.js
+++ b/client/app/components/singletrip/BarGraphComponent.js
@@ -9,8 +9,13 @@ import { load } from 'ol/Image';
 
 const BarGraphComponent = ({ tripData, expensesToDisplay, categoryData, currency }) => {
     const [loading, setLoading] = React.useState(true);
+    const [empty, setEmpty] = React.useState(false);
 
     useEffect(() => {
+        if (categoryData.datasets.length == 0) {
+            setLoading(false);
+            setEmpty(true);
+        }
         if (expensesToDisplay && categoryData && categoryData.datasets.length > 0) {
             setLoading(false); 
         }
@@ -99,6 +104,10 @@ const BarGraphComponent = ({ tripData, expensesToDisplay, categoryData, currency
     
     if (loading) {
         return <LoadingPageComponent />;
+    }
+
+    if (empty) {
+        return <p>No expense data available to display.</p>
     }
 
     return (

--- a/client/app/components/singletrip/BudgetMeterComponent.js
+++ b/client/app/components/singletrip/BudgetMeterComponent.js
@@ -3,10 +3,9 @@ import ReactSpeedometer, { Transition } from 'react-d3-speedometer';
 import currencySymbolMap from 'currency-symbol-map';
 import LoadingPageComponent from '../LoadingPageComponent';
 
-
-const BudgetMeterComponent = ({ tripData, convertedBudget, expensesToDisplay, totalExpenses, currency}) => {
+const BudgetMeterComponent = ({ tripData, convertedBudget, expensesToDisplay, totalExpenses, currency }) => {
     const currencySymbol = currencySymbolMap(currency);
-    const [loading, setLoading] = React.useState(true);
+    const [loading, setLoading] = useState(true);
 
     useEffect(() => {
         if (!expensesToDisplay) {
@@ -21,30 +20,11 @@ const BudgetMeterComponent = ({ tripData, convertedBudget, expensesToDisplay, to
         return <LoadingPageComponent />;
     }
 
-    return(
+    return (
         <div>
             <p id='budgetTitle'> Budget Meter</p>
             {expensesToDisplay && totalExpenses === 0 ? (
                 <p>Loading your budget data...</p>
-            ) : totalExpenses > convertedBudget ? (
-                <div style={{
-                    marginTop: "10px",
-                    width: "350px",
-                    height: "200px",
-                    marginLeft: "50px"
-                }}>
-                    <ReactSpeedometer
-                        width={300}
-                        minValue={0}
-                        maxValue={convertedBudget}
-                        value={convertedBudget}
-                        needleColor="steelblue"
-                        needleTransitionDuration={2500}
-                        needleTransition={Transition.easeBounceOut}
-                        segments={4}
-                        segmentColors={["#a3be8c", "#ebcb8b", "#d08770", "#bf616a"]}
-                    />
-                </div>
             ) : (
                 <div style={{
                     marginTop: "10px",
@@ -53,10 +33,11 @@ const BudgetMeterComponent = ({ tripData, convertedBudget, expensesToDisplay, to
                     marginLeft: "50px",
                 }}>
                     <ReactSpeedometer
+                        key={`${convertedBudget}-${totalExpenses}`} // to force rerender
                         width={300}
                         minValue={0}
                         maxValue={convertedBudget}
-                        value={totalExpenses}
+                        value={Math.min(totalExpenses, convertedBudget)} 
                         needleColor="steelblue"
                         needleTransitionDuration={2500}
                         needleTransition={Transition.easeBounceOut}
@@ -106,7 +87,6 @@ const BudgetMeterComponent = ({ tripData, convertedBudget, expensesToDisplay, to
                         </p>
                     )}
                 </div>
-
             )}
         </div>
     );

--- a/client/app/components/singletrip/BudgetMeterComponent.js
+++ b/client/app/components/singletrip/BudgetMeterComponent.js
@@ -9,6 +9,9 @@ const BudgetMeterComponent = ({ tripData, convertedBudget, expensesToDisplay, to
     const [loading, setLoading] = React.useState(true);
 
     useEffect(() => {
+        if (!expensesToDisplay) {
+            setLoading(false);
+        }
         if (expensesToDisplay && convertedBudget && totalExpenses) {
             setLoading(false); 
         }

--- a/client/app/components/singletrip/CategoryDataComponent.js
+++ b/client/app/components/singletrip/CategoryDataComponent.js
@@ -13,6 +13,9 @@ const CategoryDataComponent = ({ categoryData, currency }) => {
     const [loading, setLoading] = React.useState(true);
 
     useEffect(() => {
+        if (categoryData.datasets.length == 0) {
+            setLoading(false);
+        }
         if (categoryData && categoryData.datasets.length > 0) {
             setLoading(false); 
         }

--- a/client/app/components/singletrip/CategoryDataComponent.js
+++ b/client/app/components/singletrip/CategoryDataComponent.js
@@ -27,7 +27,7 @@ const CategoryDataComponent = ({ categoryData, currency }) => {
                 callbacks: {
                     label: (context) => {
                         const label = ` Total in ${currency}` || '';
-                        const value = context.raw || '';
+                        const value = context.raw.toFixed(2) || '';
                         return `${label}: ${currencySymbol}${value}`;
                     },
                 },

--- a/client/app/components/singletrip/CurrencyToggleComponent.js
+++ b/client/app/components/singletrip/CurrencyToggleComponent.js
@@ -4,7 +4,7 @@ import Switch from "react-switch";
 
 const CurrencyToggleComponent = ({ homeCurrency, otherCurrencies, toggleChange }) => {
   const [selectedToggleCurrency, setSelectedToggleCurrency] = useState("");
-  const allCurrencies = [homeCurrency, ...otherCurrencies];
+  const allCurrencies = [...new Set([homeCurrency, ...otherCurrencies].filter(Boolean))]; // unique currencies that removes undefined values
 
   const handleToggle = (currency) => {
     const newCurrency = selectedToggleCurrency === currency ? "" : currency; // if currency is already selected, allow unchecking it to reset

--- a/client/app/components/singletrip/ExpenseTableComponent.js
+++ b/client/app/components/singletrip/ExpenseTableComponent.js
@@ -11,6 +11,9 @@ const ExpenseTableComponent = ({ tripData, tripId, tripLocations, expensesToDisp
     const [loading, setLoading] = useState(true);
 
     useEffect(() => {
+        if (!expensesToDisplay) {
+            setLoading(false);
+        }
         if (expensesToDisplay && categoryData && categoryData.datasets.length > 0) {
             setLoading(false); 
         }

--- a/client/app/css/recentTrips.css
+++ b/client/app/css/recentTrips.css
@@ -21,6 +21,7 @@
     background-color: var(--lightergreen);
     color: black;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    width: 450px; 
 }
 
 .trip-image-wrapper {
@@ -38,8 +39,29 @@
     max-width: 100%; 
     max-height: 100%; 
     object-fit: contain; 
+    flex-shrink: 0;
 }
 
 .recent-trip-dates {
     font-size: 17px;
+}
+
+.trip-info {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    flex: 1;
+    text-align: left;
+}
+
+.trip-info h3 {
+    margin: 0 0 5px 0;
+    font-size: 1.2rem;
+    font-weight: bold;
+}
+
+.trip-info .recent-trip-dates {
+    margin: 0;
+    font-size: 0.9rem;
+    color: #666;
 }

--- a/client/app/homepage/page.js
+++ b/client/app/homepage/page.js
@@ -206,7 +206,7 @@ function homepage() {
                             (
                                 <h1 style={{ textAlign: "center" }}>Welcome!</h1>
                             )}
-                        <p>See where you've been:</p>
+                        <p style={{marginLeft: '-15px'}}>See where you've been:</p>
                     </div>
 
                     <div style={{ display: 'flex', justifyContent: 'space-between' }}>


### PR DESCRIPTION
## Description
- The purpose of this PR is to ensure loading screens aren't displayed when there isn't any data, and to fix bugs with the budget meter and pie chart.
- This PR belongs to ticket #247 and #256.
- Files changed: 
- single trip: BarGraphComponent, BudgetMeterComponent, CategoryDataComponent, ExpenseTableComponent, CurrencyToggleComponent.js
- homepage: MapComponent, RecentTripsComponent, recentTrips.css, homepage/page.js

## What’s in this change?
- All single trp components name above
  - Check added to not display loading screens if there is no data.
- BarGraphComponent
  - Fixed bug where the bar graph would convert to the toggled currency but wouldn't switch currencies if a toggle is switched on after that.
  - CategoryDataComponent
   - Ensured converted expenses are displayed within two decimal points when hovering over a pie slice.
 - CurrencyToggleComponent
   - Fixed bug where toggles were being made for currencies that were duplicates or didn't exist (null/undefined).
 - Upper section of homepage (recent trips and map)
   - Updated styling and positioning.

## Testing Changes
- No new testing b/c only frontend was changed.
