### PR TITLE
Update signup styling and fixed homepage trip image display

### DIFF
--- a/client/app/components/homepage/DisplayOneImageComponent.js
+++ b/client/app/components/homepage/DisplayOneImageComponent.js
@@ -1,0 +1,57 @@
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
+import '../../css/displayOneImage.css';
+import DefaultTripImagesComponent from '../singletrip/DefaultTripImagesComponent';
+
+const DisplayOneImageComponent = ({ tripId, size}) => {
+    const [aTripImage, setTripImage] = useState('');
+    const defaultImageURL = 'https://www.state.gov/wp-content/uploads/2020/11/shutterstock_186964970-scaled.jpg' // when images are not found
+
+    // images stored in the db from Unsplash
+    const fetchImages = async () => {
+        try {
+          const response = await axios.get(`${process.env.NEXT_PUBLIC_SERVER_URL}/api/images/trips/${tripId}`);
+          if (response.data && Array.isArray(response.data.data) && response.data.data.length > 0) {
+            // map over the data to extract the image URLs
+            const imageURLs = response.data.data.map(item => item.image_url);
+            setTripImage(imageURLs[0]); 
+        } else {
+            console.log("No images found");
+            setTripImage(defaultImageURL)
+        }
+        } catch (error) {
+            console.error('Error fetching images:', error);
+            setTripImage(defaultImageURL);
+          };
+    
+        }
+    useEffect(() => {
+        if (tripId != null) {
+            fetchImages();
+        }
+    }, [tripId]);
+
+    //  dynamic size class
+    const wrapperClass = `display-one-image-wrapper ${size}`;
+
+    return (
+        <div className={wrapperClass}>
+            <img src={aTripImage} alt="Trip Image"/>
+        </div>
+    );
+
+    // return (
+    //     <div className="display-one-image-wrapper">
+    //         {aTripImage && aTripImage !== "No image found" && aTripImage !== "Error fetching image" ? (
+    //             <img src={aTripImage} alt="Trip Image"/>
+    //         ) : (
+    //             <div>{aTripImage}</div> // display message
+    //         )}
+    //     </div>
+    // );
+
+
+};
+
+export default DisplayOneImageComponent;
+

--- a/client/app/components/homepage/DisplayOneImageComponent.js
+++ b/client/app/components/homepage/DisplayOneImageComponent.js
@@ -1,10 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import '../../css/displayOneImage.css';
-import DefaultTripImagesComponent from '../singletrip/DefaultTripImagesComponent';
+import LoadingPageComponent from '../LoadingPageComponent';
 
 const DisplayOneImageComponent = ({ tripId, size}) => {
     const [aTripImage, setTripImage] = useState('');
+    const [loading, setLoading] = useState(true);  // State to track loading
     const defaultImageURL = 'https://www.state.gov/wp-content/uploads/2020/11/shutterstock_186964970-scaled.jpg' // when images are not found
 
     // images stored in the db from Unsplash
@@ -22,9 +23,12 @@ const DisplayOneImageComponent = ({ tripId, size}) => {
         } catch (error) {
             console.error('Error fetching images:', error);
             setTripImage(defaultImageURL);
-          };
-    
+        } finally {
+            setLoading(false); // fetch image is complete
         }
+        
+    
+    };
     useEffect(() => {
         if (tripId != null) {
             fetchImages();
@@ -36,22 +40,14 @@ const DisplayOneImageComponent = ({ tripId, size}) => {
 
     return (
         <div className={wrapperClass}>
-            <img src={aTripImage} alt="Trip Image"/>
+            {loading ? (
+                <LoadingPageComponent />
+            ) : (
+                <img src={aTripImage} alt="Trip Image" />
+            )}
         </div>
     );
-
-    // return (
-    //     <div className="display-one-image-wrapper">
-    //         {aTripImage && aTripImage !== "No image found" && aTripImage !== "Error fetching image" ? (
-    //             <img src={aTripImage} alt="Trip Image"/>
-    //         ) : (
-    //             <div>{aTripImage}</div> // display message
-    //         )}
-    //     </div>
-    // );
-
-
+    
 };
 
 export default DisplayOneImageComponent;
-

--- a/client/app/components/homepage/RecentTripsComponent.js
+++ b/client/app/components/homepage/RecentTripsComponent.js
@@ -1,10 +1,8 @@
 import React, { useState, useEffect } from 'react';
-import axios from 'axios';
-import DefaultTripImagesComponent from '../singletrip/DefaultTripImagesComponent';
 import '../../css/recentTrips.css';
+import DisplayOneImageComponent from './DisplayOneImageComponent';
 
 const RecentTripsComponent = ({ trips }) => {
-    const [tripLocations, setTripLocations] = useState({});
     const [recentTrips, setRecentTrips] = useState([]);
 
     const DateComponent = ({ dateStr, showYear }) => {
@@ -50,47 +48,6 @@ const RecentTripsComponent = ({ trips }) => {
         setRecentTrips(updatedRecentTrips);
     }, [trips]);
 
-    const fetchAllTripLocations = async () => {
-        const locations = await Promise.all(
-            recentTrips.map(trip => {
-                return axios.get(`${process.env.NEXT_PUBLIC_SERVER_URL}/api/trip-locations/trips/${trip.trip_id}`)
-                    .then(response => ({
-                        tripId: trip.trip_id,
-                        locations: response.data.data.map(location => location.location)
-                    }))
-                    .catch(error => {
-                        console.error('Error fetching trip locations for trip ID:', trip.trip_id, error);
-                        return { tripId: trip.trip_id, locations: [] }; // Return an empty array on error
-                    });
-            })
-        );
-
-        const locationsByTripId = locations.reduce((acc, { tripId, locations }) => {
-            acc[tripId] = locations;
-            return acc;
-        }, {});
-        setTripLocations(locationsByTripId);
-    };
-
-    // const formatTripDates = (startDate, endDate) => {
-    //     console.log("startDate:", startDate);
-    //     if (startDate.split('-')[0] === endDate.split('-')[0]) {
-    //         if (startDate.split('-')[1] === endDate.split('-')[1]) {
-    //             return `${startDate.split('-')[1]}/${startDate.split('-')[0].slice(-2)}`; // same month
-    //         } else {
-    //             return `${startDate.split('-')[1]} ~ ${endDate.split('-')[1]}/${startDate.split('-')[0].slice(-2)}`; // same year
-    //         }
-    //     } else {
-    //         return `${startDate.split('-')[1]}/${startDate.split('-')[0].slice(-2)} ~ ${endDate.split('-')[1]}/${endDate.split('-')[0].slice(-2)}`; // diff years
-    //     }
-    // };    
-
-    useEffect(() => {
-        if (recentTrips.length > 0) {
-            fetchAllTripLocations();
-        }
-    }, [recentTrips]);
-
     const handleTripClick = (tripId) => {
         window.location.href = `/singletrip?tripId=${tripId}`;
     };
@@ -105,9 +62,7 @@ const RecentTripsComponent = ({ trips }) => {
                     onClick={() => handleTripClick(trip.trip_id)}
                     style={{ cursor: 'pointer', display: 'flex', alignItems: 'center', margin: '10px 0', marginRight: '-5px'}} 
                 >
-                    <div className="trip-image-wrapper">
-                        <DefaultTripImagesComponent tripId={trip.trip_id} tripLocations={tripLocations[trip.trip_id] || []} />
-                    </div>
+                    <DisplayOneImageComponent tripId={trip.trip_id} size="medium" />
                     <div className="trip-info">
                         <h3>{trip.name}</h3>
                         <p className="recent-trip-dates">

--- a/client/app/components/homepage/TripsDisplayComponent.js
+++ b/client/app/components/homepage/TripsDisplayComponent.js
@@ -8,11 +8,12 @@ import CardActionArea from "@mui/material/CardActionArea";
 import StarIcon from '@mui/icons-material/Star';
 import StarBorderIcon from '@mui/icons-material/StarBorder';
 import TripFormComponent from "./TripFormComponent";
-import DefaultTripImagesComponent from "../singletrip/DefaultTripImagesComponent";
 // import ShareTripComponent from "../singletrip/ShareTripComponent";
 // import DeleteTripComponent from "../singletrip/DeleteTripComponent";
 import "../../css/tripsDisplay.css";
 import SharedUsersComponent from "../singletrip/SharedUsersComponent";
+import DisplayOneImageComponent from './DisplayOneImageComponent';
+
 
 const TripsDisplayComponent = ({ trips, userId, homeCurrency }) => {
     const [tripLocations, setTripLocations] = useState({});
@@ -151,12 +152,7 @@ const TripsDisplayComponent = ({ trips, userId, homeCurrency }) => {
                             sx={{ width: 300, backgroundColor: 'var(--offwhite)' }}
                         >
                             <CardActionArea>
-                                <div className="trips-display-image-wrapper">
-                                    <DefaultTripImagesComponent
-                                        tripId={trip.trip_id}
-                                        tripLocations={tripLocations[trip.trip_id] || []}
-                                    />
-                                </div>
+                                <DisplayOneImageComponent tripId={trip.trip_id} size="large"/>
                                 <CardContent>
                                     <Typography gutterBottom variant="h5" component="div" sx={{ fontWeight: 'bold' }}>
                                         {trip.name}

--- a/client/app/css/displayOneImage.css
+++ b/client/app/css/displayOneImage.css
@@ -1,0 +1,36 @@
+.display-one-image-wrapper {
+    width: 290px;
+    height: 240px;
+    overflow: hidden;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border-radius: 10px;
+    position: relative;
+}
+
+.display-one-image-wrapper img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover; 
+}
+
+.display-one-image-wrapper.medium {
+    width: 230px;
+    height: 120px;
+}
+
+.display-one-image-wrapper.large {
+    width: 280px;
+    height: 140px;
+}
+
+.trips-display-image-wrapper {
+    width: 100%;
+    height: 120px;
+    overflow: hidden;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border-radius: 10px; 
+}

--- a/client/app/css/loading.css
+++ b/client/app/css/loading.css
@@ -6,7 +6,8 @@
     align-items: center;
     height: height;
     text-align: center;
-    background-color: #f0f0f0;
+    /* background-color: #f0f0f0; */
+    background-color: transparent;
     min-height: 100vh;
     max-height: 300vh;
   }

--- a/client/app/css/recentTrips.css
+++ b/client/app/css/recentTrips.css
@@ -23,25 +23,6 @@
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
     width: 450px; 
 }
-
-.trip-image-wrapper {
-    width: 240px; 
-    height: 120px; 
-    margin-right: 10px;
-    overflow: hidden; 
-    display: flex; 
-    justify-content: center; 
-    align-items: center; 
-    border-radius: 8px; 
-}
-
-.trip-image-wrapper img {
-    max-width: 100%; 
-    max-height: 100%; 
-    object-fit: contain; 
-    flex-shrink: 0;
-}
-
 .recent-trip-dates {
     font-size: 17px;
 }
@@ -52,6 +33,7 @@
     justify-content: center;
     flex: 1;
     text-align: left;
+    margin-left: 3%;
 }
 
 .trip-info h3 {

--- a/client/app/css/signup.css
+++ b/client/app/css/signup.css
@@ -1,30 +1,76 @@
 .container {
     display: flex;
-    justify-content: center;
-    align-items: center; 
-}
-
-.row {
-    display: flex; 
-    flex: 1;
-}
-
-.logo {
-    background-color: #344E41;
     height: 100vh;
+    width: 100%;}
+
+.passport-wrapper {
+    flex: 1;
     display: flex;
     justify-content: center;
     align-items: center;
+    background: linear-gradient(to bottom, #344e41e7, var(--green));
+}
+
+.passport {
+    width: 475px;
+    height: 650px;
+    position: relative;
+    border-radius: 25px;
+    overflow: hidden;
+    margin-left: 4%;
+    margin-right: 4%;
+    box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.6);
+}
+
+.passport-cover {
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    backface-visibility: hidden;
+    background: var(--darkgreen); 
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    z-index: 2;
+}
+
+.passport-logo {
+    width: 270px;
+    height: auto;
+}
+
+.passport-title {
+    font-size: 2rem;
+    font-weight: 700;
+    color: #fff;
+    text-transform: uppercase;
+    letter-spacing: 1.5px;
+    text-shadow: 2px 2px 3px rgba(0, 0, 0, 0.4);
+}
+
+.passport-spine {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 30px;
+    height: 100%;
+    background: linear-gradient(to right, #2d4030, var(--darkgreen));
+    border-radius: 25px 0 0 25px;
+    box-shadow: inset 1px 0px 5px rgba(0, 0, 0, 0.3);
 }
 
 .signIn {
     display: flex;
-    flex-direction: column; 
+    flex-direction: column;
     justify-content: center;
-    align-items: center; 
-    margin-left: 10vw;
-    margin-right: 10vw;
+    align-items: center;
+    margin-left: 0vw;
+    margin-right: 0vw;
     height: 100vh;
+    width: 62vw;
+    background: white;
 }
 
 .signInGoogle {
@@ -39,4 +85,18 @@
 .description {
     margin-bottom: 2vw;
     margin-top: 1vw;
+}
+
+@media (max-width: 800px) {
+    .passport-wrapper {
+        display: none; /* hide passport on smaller screens */
+    }
+
+    .signIn {
+        flex: 1;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        padding: 0 5%;
+    }
 }

--- a/client/app/css/tripsDisplay.css
+++ b/client/app/css/tripsDisplay.css
@@ -25,23 +25,6 @@
     text-align: left;
 }
 
-.trips-display-image-wrapper {
-    width: 100%;
-    height: 120px;
-    overflow: hidden;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    border-radius: 10px; 
-}
-
-.trips-display-image-wrapper img {
-    max-width: 100%;
-    max-height: 100%;
-    object-fit: contain;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-}
-
 .favorite-icon {
     cursor: pointer;
     position: absolute;

--- a/client/app/signup/page.js
+++ b/client/app/signup/page.js
@@ -46,27 +46,33 @@ function Signup() {
     return (
         <GoogleOAuthProvider clientId={googleID}>
             <ToastContainer hideProgressBar={true} />
-            <div className={`container text-center ${inriaSans.className}`}>
-                <div className='row'>
-                    <div className='col-md-6 logo'>
-                        <Image src={logo} alt="Logo" width={"15vw"} height={"15vw"} priority/>
+            <div className={`container ${inriaSans.className}`}>
+                <div className="passport-wrapper">
+                    <div className="passport">
+                        <div className="passport-cover">
+                            <div className="passport-spine"></div>
+                            <Image src={logo} alt="Trip Trends Logo" className="passport-logo" />
+                            <p className="passport-title">Trip Trends</p>
+                        </div>
                     </div>
-                    <div className='col-md-6 signIn'>
-                        <div>
-                            <h1 className='signInGoogle'>Sign In With Google</h1>
+                </div>
+                <div className="signIn">
+                    <div>
+                        <h1 className='signInGoogle'>Sign In With Google</h1>
                             <GoogleLogin
                                 onSuccess={handleLoginSuccess}
                                 onError={handleLoginFailure}
                             />
-                            <h2 className='welcome'>Welcome to Trip Trends!</h2>
-                            <p className='description'>We hope you enjoy your adventure with our easily accessible and modernized app. Here’s to a great time!</p>
-                        </div>
+                        <h2 className='welcome'>Welcome to Trip Trends!</h2>
+                        <p className='description'>We hope you enjoy your adventure with our easily accessible and modernized app. Here’s to a great time!</p>
                     </div>
                 </div>
             </div>
         </GoogleOAuthProvider>
-
     );
+    
+    
+    
 }
 
 export default Signup;


### PR DESCRIPTION
## Description
- The purpose of this PR is to fix the bug where images in the trip display in homepage has a split image (2 images on top of each other) for multiple trip locations. Signup styling also updated.
- This PR belongs to ticket #222 
- Homepage and signup .js files and .css files updated

## What’s in this change?
- DisplayOneImageComponent and displayOneImage.css
  - New component added to display one trip image no matter the number of trip locations for a trip.
  - GET endpoint called to fetch image URLs for each trip.
  - Dynamic styling added to be able to be displayed in the trip cards and in recent trips since both require different dimensions.
  - Added the loading component when images are still being fetched instead of the alt text.
  - If trip image are not found, default photo added with an airplane.
- RecentTripComponent, TripsDisplayComponent, recentTrips.css, tripsDisplay.css
  - Removed unnecessary code and styling in order to reuse the new component in both.
- signup/page.js and signup.css
  - Updated styling to make the left side look like a passport.
  - Added a green gradient on the left background.

## Testing Changes
- No new tests. Frontend changes only and calling the app's endpoint.
