### PR TITLE
added a + button to add events to list and don't return image col

### DIFF
--- a/client/app/components/singletrip/EventsComponent.js
+++ b/client/app/components/singletrip/EventsComponent.js
@@ -1,6 +1,8 @@
 import React, { useEffect, useState, useRef } from 'react';
 import '../../css/discover.css';
 import axios from 'axios';
+import { ToastContainer, toast } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 
 
 const EventComponent = ({ tripId }) => {
@@ -101,14 +103,57 @@ const EventComponent = ({ tripId }) => {
             });
     };
 
+    const handleAddEvent = (event) => {
+        console.log('Event added:', event);
+        if (!event.name) {
+            toast.error("Event name is missing. Please provide a valid event.");
+            setTimeout(() => {
+            }, 500);
+        } else {
+            const newEvent = {
+                name: event.name,
+                list_type: "sightseeing",
+                is_completed: false
+            };
+
+            console.log("ADDING EVENT: ", newEvent);
+
+            const eventBody = {
+                name: newEvent.name,
+                list_type: "sightseeing",
+                is_completed: false
+            };
+
+            axios.post(`${process.env.NEXT_PUBLIC_SERVER_URL}/api/lists/create-item/${tripId}`, eventBody)
+                .then((response) => {
+                    console.log(response);
+                    toast.success("Event added successfully!");
+                    setTimeout(() => {
+                    }, 500);
+                })
+                .catch((error) => {
+                    console.error("Error adding event:", error);
+                    toast.error("Failed to add the event.");
+                    setTimeout(() => {
+                    }, 500);
+                });
+        }
+    };
+
     return (
         <div className="event-widget-container">
             <div className="event-widget">
-                <h2 className='EvenHeader'>Events</h2>
+                <h2 className="EvenHeader">Events</h2>
                 <div className="event-container">
                     {eventsData.length > 0 ? (
                         eventsData.map((event, index) => (
                             <div key={index} className="event-card">
+                                <button
+                                    className="add-button"
+                                    onClick={() => handleAddEvent(event)}
+                                >
+                                    +
+                                </button>
                                 {event.images && event.images.length > 0 ? (
                                     <img
                                         src={event.images[0].url}
@@ -129,7 +174,12 @@ const EventComponent = ({ tripId }) => {
                                         <p className="event-loc">{event._embedded?.venues[0]?.city?.name}</p>
                                     </div>
                                     <p>
-                                        <a href={event.url} target="_blank" rel="noopener noreferrer" className="event-detail">
+                                        <a
+                                            href={event.url}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            className="event-detail"
+                                        >
                                             View Event Details
                                         </a>
                                     </p>

--- a/client/app/css/discover.css
+++ b/client/app/css/discover.css
@@ -117,3 +117,44 @@
     text-decoration: underline;
     color: #0056b3; 
 }
+
+.add-button {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background-color: #ffffff;
+    color: #333333;
+    border: 1px solid rgba(0, 0, 0, 0.1);
+    border-radius: 12px;
+    padding: 6px 12px;
+    font-size: 14px;
+    font-weight: bold;
+    cursor: pointer;
+    transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+    box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.add-button:hover {
+    background-color: #f9f9f9;
+    color: #000000;
+    transform: scale(1.1);
+    box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.15);
+}
+
+.event-card {
+    position: relative;
+    background-color: #ffffff;
+    border-radius: 12px;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    width: 280px;
+    overflow: hidden;
+    font-family: Arial, sans-serif;
+    transition: transform 0.2s ease-in-out;
+}
+
+.event-card:hover {
+    transform: scale(1.02);
+    box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
+}
+
+

--- a/client/app/singletrip/page.js
+++ b/client/app/singletrip/page.js
@@ -7,6 +7,8 @@ import axios from 'axios';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'react-calendar/dist/Calendar.css';
 import { Chart, ArcElement, Tooltip, Legend } from 'chart.js';
+import { toast } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 
 // Import components
 import DownloadTripComponent from '../components/singletrip/DownloadTripComponent';

--- a/server/controllers/ExpenseController.js
+++ b/server/controllers/ExpenseController.js
@@ -113,7 +113,10 @@ const getExpensesByTripId = async (req, res) => {
         if (!tripId) {
             return res.status(400).json({ message: "Trip ID is required" });
         }
-        const expense = await Expense.findAll({ where: { trip_id: tripId } });
+        const expense = await Expense.findAll({
+            where: { trip_id: tripId },
+            attributes: { exclude: ['image'] }, // Exclude the 'image' column
+        });
         if (!expense || expense.length === 0) {
             return res.status(404).json({ message: "Expense not found" });
         }

--- a/server/tests/expenseController.test.js
+++ b/server/tests/expenseController.test.js
@@ -189,8 +189,10 @@ describe('Expense Controller', () => {
         // Call the getExpensesByTripId function
         await getExpensesByTripId(mockRequest, mockResponse);
     
-        // Check that Expense.findAll was called with the correct trip_id
-        expect(Expense.findAll).toHaveBeenCalledWith({ where: { trip_id: mockTripId } });
+        expect(Expense.findAll).toHaveBeenCalledWith({
+            where: { trip_id: mockTripId },
+            attributes: { exclude: ['image'] } // Include the exclusion of the 'image' attribute
+        });
     
         // Check that the status 200 was returned
         expect(mockResponse.status).toHaveBeenCalledWith(200);


### PR DESCRIPTION
## Description
- The purpose of this PR is to add an event to the sightseeing list from Discover page. Don't return the receipt image in expenses. 
- The PR belongs to #290 
- `client/app/components/singletrip/EventsComponent.js` `client/app/css/discover.css` `server/controllers/ExpenseController.js`

## What’s in this change?
-`client/app/components/singletrip/EventsComponent.js`
  - Add + button to each event card.
  - The button will add that event to the sightseeing list.
- `client/app/css/discover.css` 
  - Styling for + button
- `server/controllers/ExpenseController.js`
 -  Updated get expenses function not to return receipt

## Testing Changes
- Unit test coverage report
- updated get expenses test.