### PR TITLE
Added nav bar across pages and fixed currency change bug

### DIFF
--- a/client/app/components/singletrip/ExpenseTableComponent.js
+++ b/client/app/components/singletrip/ExpenseTableComponent.js
@@ -5,9 +5,10 @@ import '../../css/ExpenseTableComponent.css';
 import currencySymbolMap from 'currency-symbol-map';
 import LoadingPageComponent from '../LoadingPageComponent';
 
-const ExpenseTableComponent = ({ tripData, tripId, tripLocations, expensesToDisplay, currencyCodes, expenseCategories, categoryData }) => {
+const ExpenseTableComponent = ({ tripData, tripId, tripLocations, expensesToDisplay, currencyCodes, expenseCategories, categoryData, selectedCurrency, setSelectedCurrency, otherCurrencies}) => {
     const [isEditPopupVisible, setEditPopupVisible] = useState(false);
     const [selectedExpense, setSelectedExpense] = useState(null);
+    const [localFormCurrency, setLocalFormCurrency] = useState(selectedCurrency);
     const [loading, setLoading] = useState(true);
 
     useEffect(() => {
@@ -27,8 +28,25 @@ const ExpenseTableComponent = ({ tripData, tripId, tripLocations, expensesToDisp
         }));
     };
 
+    const handleCurrencyChange = (e) => {
+        setLocalFormCurrency(e.target.value);
+    };
+
+    const handleEditClick = (expense) => {
+        setEditPopupVisible(true);
+        setSelectedExpense(expense);
+        setLocalFormCurrency(expense.currency);
+    };
+
     const submitEditExpense = async (expenseID) => {
-        axios.put(`${process.env.NEXT_PUBLIC_SERVER_URL}/api/expenses/${expenseID}`, selectedExpense)
+        const updatedExpense = { ...selectedExpense, currency: localFormCurrency };
+
+        // update global currency if it is different
+        if (selectedExpense.currency !== localFormCurrency) {
+            // update global currency
+            setSelectedCurrency(localFormCurrency);
+        }
+        axios.put(`${process.env.NEXT_PUBLIC_SERVER_URL}/api/expenses/${expenseID}`, updatedExpense)
             .then(response => {
                 console.log(response)
                 window.location.reload();
@@ -104,11 +122,13 @@ const ExpenseTableComponent = ({ tripData, tripId, tripLocations, expensesToDisp
                                 {expensesToDisplay.map((expense) => {
                                     const categoryIndex = categoryData.labels.indexOf(expense.category);
                                     const tagColor = categoryData.datasets[0].backgroundColor[categoryIndex];
-                                    const currencySymbol = currencySymbolMap(expense.currency);
                                     return (
                                         <tr key={expense.expense_id}>
                                             <td>{expense.name}</td>
-                                            <td>{currencySymbol}{expense.amount}</td>
+                                            <td>
+                                                {currencySymbolMap(expense.currency)}
+                                                {expense.amount}
+                                            </td>
                                             <td>{expense.currency}</td>
                                             <td>
                                                 {/* Category with color tag */}
@@ -133,10 +153,7 @@ const ExpenseTableComponent = ({ tripData, tripId, tripLocations, expensesToDisp
                                                 <div className="icon-div" tooltip="Edit Trip" tabIndex="0">
                                                     <div className="icon-SVG">
                                                         <svg
-                                                            onClick={() => {
-                                                                setEditPopupVisible(true);
-                                                                setSelectedExpense(expense);
-                                                            }}
+                                                            onClick={() => handleEditClick(expense)}
                                                             xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.3" stroke="currentColor" className="size-6">
                                                             <path strokeLinecap="round" strokeLinejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
                                                         </svg>
@@ -189,23 +206,52 @@ const ExpenseTableComponent = ({ tripData, tripId, tripLocations, expensesToDisp
                                                                                     pointerEvents: 'none',
                                                                                 }}
                                                                             >
-                                                                                {currencySymbol}
+                                                                                {currencySymbolMap(localFormCurrency)}
                                                                             </span>
                                                                         </label>
                                                                         <label className="edit-expense-field-label">
                                                                             Currency:
                                                                             <select
                                                                                 name="currency"
-                                                                                value={selectedExpense.currency}
-                                                                                onChange={handleEditChange}
+                                                                                value={localFormCurrency}
+                                                                                onChange={handleCurrencyChange}
                                                                                 required
                                                                             >
-                                                                                <option value="">Select Currency</option>
-                                                                                {currencyCodes.map((code) => (
-                                                                                    <option key={code} value={code}>{code}</option>
-                                                                                ))}
+                                                                                <option value="" disabled>Select Currency</option>
+
+                                                                                {/* Display the selected currency at the top if it exists */}
+                                                                                {localFormCurrency && (
+                                                                                    <option value={localFormCurrency}>{localFormCurrency}</option>
+                                                                                )}
+
+                                                                                {/* Recommended currencies */}
+                                                                                {otherCurrencies
+                                                                                    .filter((code) => code !== localFormCurrency)
+                                                                                    .map((code, index) => (
+                                                                                        <option key={`other-${index}`} value={code}>
+                                                                                            {code}
+                                                                                        </option>
+                                                                                    ))}
+
+                                                                                {/* USD as a fallback option */}
+                                                                                <optgroup label="Other">
+                                                                                    <option value="USD">USD</option>
+                                                                                    {currencyCodes
+                                                                                        .filter(
+                                                                                            (code) =>
+                                                                                                code !== localFormCurrency &&
+                                                                                                code !== "USD" &&
+                                                                                                !otherCurrencies.includes(code)
+                                                                                        )
+                                                                                        .map((code) => (
+                                                                                            <option key={code} value={code}>
+                                                                                                {code}
+                                                                                            </option>
+                                                                                        ))}
+                                                                                </optgroup>
                                                                             </select>
                                                                         </label>
+
                                                                     </div>
                                                                     <div className="field-pair">
                                                                         <label className="edit-expense-field-label">

--- a/client/app/components/singletrip/GeneralTripInfoComponent.js
+++ b/client/app/components/singletrip/GeneralTripInfoComponent.js
@@ -168,13 +168,6 @@ const GeneralTripInfoComponent = ({ tripData, convertedBudget, tripId, tripLocat
                         </div>
                     </div>
                 </div>
-
-                <div className="trip-overview-div"  style={{cursor: "pointer"}} onClick={() => window.location.href = `/discover?tripId=${tripId}`}>
-                    <div id="trip-locations-circle">✈️</div>
-                    <div className="trip-overview-content">
-                            <p>Discover Page</p>                   
-                    </div>
-                </div>
             </div>
 
 

--- a/client/app/components/singletrip/NavBarComponent.js
+++ b/client/app/components/singletrip/NavBarComponent.js
@@ -1,0 +1,72 @@
+import { React, useState, useEffect } from 'react';
+import { Navbar, Nav, Container } from 'react-bootstrap';
+import '../../css/navbar.css';
+
+const NavBarComponent = ({ tripId, userRole, tripName, pointerDisabled = false }) => {
+    const [activeLink, setActiveLink] = useState(`/singletrip?tripId=${tripId}`);
+    const [isPointerDisabled, setIsPointerDisabled] = useState(pointerDisabled);
+
+    const handleActiveLink = () => {
+        if (typeof window !== 'undefined') {
+            const path = window.location.pathname;
+            if (path === '/gallery') {
+                setActiveLink('gallery');
+            } 
+            else if (path === '/todo') {
+                setActiveLink('todo');
+            } 
+            else if (path === '/discover') {
+                setActiveLink('discover');
+            } 
+            else {
+                setActiveLink(`/singletrip?tripId=${tripId}`);
+            }
+        }
+    };
+
+    useEffect(() => {
+        if (typeof window !== 'undefined') {
+            handleActiveLink();
+        }
+    }, []);
+
+    return (
+        <div style={{ marginLeft: '2%', marginTop: '1%' }}>
+            <Navbar expand="lg" variant="light">
+                <Container>
+                    <Navbar.Toggle aria-controls="basic-navbar-nav" style={{ backgroundColor: 'transparent', border: 'none', boxShadow: 'none', pointerEvents: isPointerDisabled ? 'none' : 'auto'}}/>
+                    <Navbar.Collapse id="basic-navbar-nav">
+                    <Nav>
+                        <Nav.Link
+                            className={activeLink === `/singletrip?tripId=${tripId}` ? 'active' : ''}
+                            onClick={() => { setActiveLink(`/singletrip?tripId=${tripId}`), window.location.href = `/singletrip?tripId=${tripId}`;
+                            }}>
+                            {tripName} Home
+                        </Nav.Link>
+                        <Nav.Link
+                            className={activeLink === 'gallery' ? 'active' : ''}
+                            onClick={() => { setActiveLink('gallery'), window.location.href = `/gallery?tripId=${tripId}&userRole=${userRole}`;
+                            }}>
+                            Gallery
+                        </Nav.Link>
+                        <Nav.Link
+                            className={activeLink === 'todo' ? 'active' : ''}
+                            onClick={() => { setActiveLink('todo'), window.location.href = `/todo?tripId=${tripId}`;
+                            }}>
+                            Lists
+                        </Nav.Link>
+                        <Nav.Link
+                            className={activeLink === 'discover' ? 'active' : ''}
+                            onClick={() => { setActiveLink('discover'), window.location.href = `/discover?tripId=${tripId}`;
+                            }}>
+                            Discover
+                        </Nav.Link>
+                    </Nav>
+                    </Navbar.Collapse>
+                </Container>
+            </Navbar>
+        </div>
+    );
+};
+
+export default NavBarComponent;

--- a/client/app/components/singletrip/TripIconBarComponent.js
+++ b/client/app/components/singletrip/TripIconBarComponent.js
@@ -44,32 +44,8 @@ const TripIconBarComponent = ({ tripId, userId, isOwner, tripData, tripLocations
             <ShareTripComponent tripId={tripId} isOwner={isOwner} />
             {/* Edit Trip Button */}
             <EditTripComponent tripId={tripId} tripData={tripData} tripLocations={tripLocations} userRole={userRole} onUpdate={fetchTripData} homeCurrency={homeCurrency} />
-            {/* Download Trip Button */}
-            {/* <DownloadTripComponent tripData={tripData} tripId={tripId} /> */}
             {/* Delete Trip Button */}
             <DeleteTripComponent tripId={tripId} userRole={userRole} />
-            {/* Gallery Button */}
-            <div className="icon-div gallery-icon" tooltip="Gallery" tabIndex="0">
-                <div className="icon-SVG">
-                    <div onClick={() => window.location.href = `/gallery?tripId=${tripId}&userRole=${userRole}`}>
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.3" stroke="currentColor" className="size-6">
-                            <path strokeLinecap="round" strokeLinejoin="round" d="m2.25 15.75 5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.909 2.909m-18 3.75h16.5a1.5 1.5 0 0 0 1.5-1.5V6a1.5 1.5 0 0 0-1.5-1.5H3.75A1.5 1.5 0 0 0 2.25 6v12a1.5 1.5 0 0 0 1.5 1.5Zm10.5-11.25h.008v.008h-.008V8.25Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z" />
-                        </svg>
-                        <span className="icon-text">Gallery</span>
-                    </div>
-                </div>
-            </div>
-            {/* To Do List Button */}
-            <div className="icon-div todo-icon" tooltip="To-Do" tabIndex="0">
-                <div className="icon-SVG">
-                    <div onClick={() => window.location.href = `/todo?tripId=${tripId}`}>
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.3" stroke="currentColor" className="size-6">
-                            <path strokeLinecap="round" strokeLinejoin="round" d="M12 7.5h1.5m-1.5 3h1.5m-7.5 3h7.5m-7.5 3h7.5m3-9h3.375c.621 0 1.125.504 1.125 1.125V18a2.25 2.25 0 0 1-2.25 2.25M16.5 7.5V18a2.25 2.25 0 0 0 2.25 2.25M16.5 7.5V4.875c0-.621-.504-1.125-1.125-1.125H4.125C3.504 3.75 3 4.254 3 4.875V18a2.25 2.25 0 0 0 2.25 2.25h13.5M6 7.5h3v3H6v-3Z" />
-                        </svg>
-                        <span className="icon-text">To-Do List</span>
-                    </div>
-                </div>
-            </div>
         </header>
     )
 }

--- a/client/app/components/singletrip/UploadTripImage.js
+++ b/client/app/components/singletrip/UploadTripImage.js
@@ -95,17 +95,14 @@ const TripImageComponent = ({ tripId }) => {
         }
     };
 
-
-
-
     return (
         <div>
             <div>
-                {/* Add Image Button */}
+                {/* Add Image Upload Button */}
                 <div className="icon-div" onClick={handleAddImageClick} tooltip="Add Image" tabIndex="0">
                     <div className="icon-SVG">
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.3" stroke="currentColor" className="size-6">
-                            <path strokeLinecap="round" strokeLinejoin="round" d="m2.25 15.75 5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.909 2.909m-18 3.75h16.5a1.5 1.5 0 0 0 1.5-1.5V6a1.5 1.5 0 0 0-1.5-1.5H3.75A1.5 1.5 0 0 0 2.25 6v12a1.5 1.5 0 0 0 1.5 1.5Zm10.5-11.25h.008v.008h-.008V8.25Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z" />
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.3" stroke="currentColor" class="size-6">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 7.5h-.75A2.25 2.25 0 0 0 4.5 9.75v7.5a2.25 2.25 0 0 0 2.25 2.25h7.5a2.25 2.25 0 0 0 2.25-2.25v-7.5a2.25 2.25 0 0 0-2.25-2.25h-.75m0-3-3-3m0 0-3 3m3-3v11.25m6-2.25h.75a2.25 2.25 0 0 1 2.25 2.25v7.5a2.25 2.25 0 0 1-2.25 2.25h-7.5a2.25 2.25 0 0 1-2.25-2.25v-.75" />
                         </svg>
                         <span className="icon-text">Upload Image</span>
                     </div>

--- a/client/app/css/dropdown.css
+++ b/client/app/css/dropdown.css
@@ -10,14 +10,14 @@
 }
 
 .dropdown-button:hover {
-    background-color: #7cb37b;
+    background-color: var(--lightergreen);
     color: white;
     box-shadow: none;
 }
 
 .dropdown-button:active,
 .dropdown-button:focus {
-    background-color: #7cb37b;
+    background-color: var(--lightergreen);
     color: white;
     box-shadow: none;
 }
@@ -32,7 +32,7 @@
 }
 
 .dropdown-item:hover {
-    background-color: #7cb37b !important;
+    background-color: var(--lightergreen) !important;
     color: black !important;
 }
 

--- a/client/app/css/navbar.css
+++ b/client/app/css/navbar.css
@@ -1,0 +1,25 @@
+.nav-link.active {
+    font-weight: bold;
+    color: white !important;
+}
+
+.nav-link {
+    margin-right: 10px;
+    position: relative;
+    padding: 5px 10px;
+    border-radius: 12px;
+    text-decoration: none;
+    transition: background-color 0.3s, color 0.3s;
+    z-index: 1000;
+    max-width: 60%;
+}
+
+.nav-link:hover {
+    background-color: var(--lightergreen);
+    color: white;
+}
+
+.nav-link.active {
+    background-color: var(--lightergreen);
+    color: white;
+}

--- a/client/app/css/tripForm.css
+++ b/client/app/css/tripForm.css
@@ -10,7 +10,6 @@
 }
 
 .dropdown-suggestions {
-
     background-color: white; /* Background for visibility */
     border: 1px solid #ccc; /* Border for separation */
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1); /* Adds depth */
@@ -19,6 +18,7 @@
     z-index: 1000; /* Ensure it appears above other elements */
     width: 100%; /* Match the width of the input */
     display: block;
+    border-radius: 8px;
 }
 
 .dropdown-suggestion {

--- a/client/app/css/uploadImage.css
+++ b/client/app/css/uploadImage.css
@@ -24,3 +24,16 @@
     0% { transform: rotate(0deg); }
     100% { transform: rotate(360deg); }
 }
+
+.icon-div {
+    box-sizing: border-box;
+    height: 56px;
+    width: 56px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    cursor: pointer;
+    transition: background-color 300ms ease, transform 300ms ease;
+    left: 1.5%;
+}

--- a/client/app/gallery/page.js
+++ b/client/app/gallery/page.js
@@ -4,6 +4,8 @@ import React, { useEffect, useState } from 'react';
 import TripImageComponent from '../components/singletrip/TripImageComponent';
 import UploadTripImage from '../components/singletrip/UploadTripImage';
 import HeaderComponent from '../components/HeaderComponent';
+import NavBarComponent from '../components/singletrip/NavBarComponent';
+import LoadingPageComponent from '../components/LoadingPageComponent';
 import axios from 'axios';
 
 function Gallery() {
@@ -11,6 +13,7 @@ function Gallery() {
     const [userRole, setUserRole] = useState(null);
     const [userId, setUserId] = useState(null);
     const [userName, setUserName] = useState("");
+    const [tripName, setTripName] = useState('');
 
     const getUserId = () => {
         const user_id = localStorage.getItem("user_id");
@@ -41,8 +44,21 @@ function Gallery() {
         setTripId(tripId);
         setUserRole(userRole);
 
+        const fetchTripName = () => {
+            if (tripId) {
+                axios.get(`${process.env.NEXT_PUBLIC_SERVER_URL}/api/trips/${tripId}`)
+                    .then(response => {
+                        setTripName(`${response.data.data.name}`);
+                    })
+                    .catch(error => {
+                        console.error('Error fetching trip data:', error);
+                    })
+            }
+        };
+
         getUserId();
         fetchUserName();
+        fetchTripName();
     }, []);
 
     if (!tripId || !userRole) {
@@ -53,9 +69,7 @@ function Gallery() {
                     setUserName={setUserName}
                     userId={userId}
                 />
-                <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', textAlign: 'center' }}>
-                    <p>Loading your Gallery...</p>
-                </div>
+                <LoadingPageComponent />
             </div>
         );
     }
@@ -67,15 +81,9 @@ function Gallery() {
                 setUserName={setUserName}
                 userId={userId}
             />
+            <NavBarComponent tripId={tripId} userRole={userRole} tripName={tripName} pointerDisabled={true}/>
             <header className="top-icon-bar-header" style={{ display: 'flex', alignItems: 'center', width: '100%' }}>
-                <div className="icon-div" onClick={() => window.location.href = `/singletrip?tripId=${tripId}`} tooltip="Back" tabIndex="0" style={{ display: 'flex', cursor: 'pointer', alignItems: 'center' }}>
-                    <div className="icon-SVG">
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.3" stroke="currentColor" className="size-6" style={{ width: '24px', height: '24px' }}>
-                            <path strokeLinecap="round" strokeLinejoin="round" d="M9 15 3 9m0 0 6-6M3 9h12a6 6 0 0 1 0 12h-3" />
-                        </svg>
-                        <span className="icon-text">Back</span>
-                    </div>
-                </div>
+                
                 <div className="icon-div" tooltip="Gallery" tabIndex="0" style={{ display: 'flex', cursor: 'pointer' }}>
                     {userRole === 'owner' || userRole === 'editor' ? (
                         <UploadTripImage tripId={tripId} />

--- a/client/app/singletrip/page.js
+++ b/client/app/singletrip/page.js
@@ -24,6 +24,7 @@ import TripImageComponent from '../components/singletrip/TripImageComponent';
 import UploadTripImage from '../components/singletrip/UploadTripImage';
 import CurrencyToggleComponent from '../components/singletrip/CurrencyToggleComponent'
 import LoadingPageComponent from '../components/LoadingPageComponent';
+import NavBarComponent from '../components/singletrip/NavBarComponent';
 
 
 Chart.register(ArcElement, Tooltip, Legend);
@@ -50,6 +51,7 @@ function Singletrip() {
     const [selectedFilter, setSelectedFilter] = useState('');
     const [tripLocations, setTripLocations] = useState([]);
     const [expenseUSD, setExpenseUSD] = useState([]);
+    const [tripName, setTripName] = useState('');
 
     const [selectedCategory, setSelectedCategory] = useState('');
     const [isDropdownVisible, setIsDropdownVisible] = useState(false);
@@ -525,6 +527,7 @@ function Singletrip() {
     useEffect(() => {
         if (tripData) {
             convertBudget(tripData.data.budget);
+            setTripName(tripData.data.name);
         }
     }, [selectedToggleCurrency, tripData]);
 
@@ -545,6 +548,7 @@ function Singletrip() {
             <div className="main-container">
                 {tripData ? (
                     <div>
+                        <NavBarComponent tripId={tripId} userRole={userRole} tripName={tripName}/>
                         <div className='container'>
                             {/* Icon Bar Above Trip Info */}
                             <TripIconBarComponent
@@ -708,7 +712,8 @@ function Singletrip() {
                             <div className='row' style={{ justifyContent: 'center', alignItems: 'center', display: 'flex', textAlign: 'center' }}>
                                 {/* Expense Table */}
                                 <ExpenseTableComponent tripData={tripData} tripId={tripId} tripLocations={tripLocations} expensesToDisplay={expensesToDisplay}
-                                    currencyCodes={currencyCodes} expenseCategories={expenseCategories} userRole={userRole} categoryData={categoryData} />
+                                    currencyCodes={currencyCodes} expenseCategories={expenseCategories} userRole={userRole} categoryData={categoryData} 
+                                    selectedCurrency={selectedCurrency} setSelectedCurrency={setSelectedCurrency} otherCurrencies={otherCurrencies} />
                             </div>
                             <br></br>
                             <br></br>

--- a/client/app/todo/page.js
+++ b/client/app/todo/page.js
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState } from 'react';
 import HeaderComponent from '../components/HeaderComponent';
+import NavBarComponent from '../components/singletrip/NavBarComponent';
 import axios from 'axios';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
@@ -24,6 +25,9 @@ function TodoList() {
     const [tripId, setTripId] = useState(null);
     const [userId, setUserId] = useState(null);
     const [userName, setUserName] = useState("");
+    const [userRole, setUserRole] = useState(null);
+    const [tripName, setTripName] = useState('');
+    const isOwner = userRole === 'owner';
     const [checked, setChecked] = React.useState([]);
     const [purchaseList, setPurchaseList] = useState([]);
     const [sightseeingList, setSightseeingList] = useState([]);
@@ -235,9 +239,46 @@ function TodoList() {
                 });
         }
 
+        const fetchTripName = () => {
+            if (tripId) {
+                axios.get(`${process.env.NEXT_PUBLIC_SERVER_URL}/api/trips/${tripId}`)
+                    .then(response => {
+                        setTripName(`${response.data.data.name}`);
+                    })
+                    .catch(error => {
+                        console.error('Error fetching trip data:', error);
+                    })
+            }
+          };
+
         getUserId();
         fetchUserName();
+        fetchTripName()
     }, []);
+
+    useEffect(() => {
+        const fetchUserRole = async () => {
+            if (tripId && userId) {
+                try {
+                    const response = await axios.get(`${process.env.NEXT_PUBLIC_SERVER_URL}/api/shared-trips/trips/${tripId}`);
+                    const sharedTrips = response.data.data;
+                    const userRole = sharedTrips.find(trip => trip.user_id === userId)?.role;
+                    if (userRole) {
+                        setUserRole(userRole);
+                    } else {
+                        console.log("User does not have a role for this trip.");
+                    }
+                } catch (error) {
+                    console.error('Error fetching user role:', error);
+                    // setError('Error fetching user role. Please try again later.');
+                }
+            } else {
+                console.log("tripId or userId is missing.");
+            }
+        };
+        fetchUserRole();
+    
+    }, [tripId]);
 
     // console.log("PLIST: ", purchaseList);
     // console.log("SLIST: ", sightseeingList);
@@ -249,16 +290,9 @@ function TodoList() {
                 setUserName={setUserName}
                 userId={userId}
             />
-            <div className="icon-div" onClick={() => window.location.href = `/singletrip?tripId=${tripId}`} tooltip="Back" tabIndex="0" style={{ display: 'flex', cursor: 'pointer', alignItems: 'center' }}>
-                <div className="icon-SVG">
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.3" stroke="currentColor" className="size-6" style={{ width: '24px', height: '24px' }}>
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M9 15 3 9m0 0 6-6M3 9h12a6 6 0 0 1 0 12h-3" />
-                    </svg>
-                    <span className="icon-text">Back</span>
-                </div>
-            </div>
+            <NavBarComponent tripId={tripId} userRole={userRole} tripName={tripName} pointerDisabled={true}/>
 
-            <div className='list-container'>
+            <div className='list-container' style ={{marginTop: '25px'}}>
                 <div className="row" style={{ display: 'flex', justifyContent: 'space-between' }}>
                     <div className="col list-display" style={{ flex: 1 }}>
                         {/* Add Purchase Item */}


### PR DESCRIPTION
## Description
- The purpose of this PR is to add a nav bars for page navigation, and fix the bug in the edit expense form when currency is changed, the symbol wasn't being updated to reflect the selected currency.
- This PR belongs to #298 
- Different components, pages, and css files.

## What’s in this change?
- ExpenseTableComponent.js, singleTrip/page.js
  - Added localCurrency state to track currencies being selected within the expense form, which impacts the symbol being displayed in the form. The actual expense currency and symbol only get updated once submitted, and the form clears if not submitted.
  - Just like the New Trip form, added recommended currencies and selected currency at the top of the currency options.
 
BEFORE: (currency selected not reflected in the symbol)
<img width="483" alt="Screenshot 2024-11-25 at 12 30 13 AM" src="https://github.com/user-attachments/assets/dff4b1c2-6f6a-4253-a4f6-c6a08448aeae">

AFTER: (AUD was the original, BDT selected)
<img width="483" alt="Screenshot 2024-11-25 at 12 44 20 AM" src="https://github.com/user-attachments/assets/df8f99bf-c01d-4f3f-bf4d-51d31d27e0b0">

- NavBarComponent.js, discover/page.js, todo/page.js, gallery/page.js, navbar.css, GeneralTripInfoComponent.js, TripIconBarComponent.js, 
  - Added new component for the navbar, and the navbar is displayed in the child pages of single trip view.
  - Added styling to the navabar. The selected page is bolded and has a background color to signify that the user is viewing that page. 
   - Removed back buttons in the child pages since navbar has a home option to go back.
   - Removed buttons that took the user to different pages.
 
BEFORE: in single trip view
 <img width="1315" alt="Screenshot 2024-11-25 at 12 31 12 AM" src="https://github.com/user-attachments/assets/cd29f09d-5154-4d80-9488-9c388f2a57b8">

AFTER: in single trip view
<img width="1640" alt="Screenshot 2024-11-25 at 12 40 56 AM" src="https://github.com/user-attachments/assets/82992f55-6231-41b5-b62d-2f1873130345">

BEFORE: in a different page (gallery)
<img width="1210" alt="Screenshot 2024-11-25 at 12 38 18 AM" src="https://github.com/user-attachments/assets/94d42161-c198-4e62-b57a-6823bbd275ef">

AFTER: in a different page (gallery)
<img width="1708" alt="Screenshot 2024-11-25 at 12 40 15 AM" src="https://github.com/user-attachments/assets/b4c481f6-7b77-4446-8ee8-1f21831cf2d7">

- uploadImage.css, tripForm.css, dropdown.css, UploadTripImage.js, 
  - Additional styling and small changes added (switched upload gallery image icon) and other color changes.


## Testing Changes
- Unit test coverage report
- Explain why there is a drop in test coverage if there is any
