### PR TITLE
Fixed Bar Graph and Homepage spacing

### DIFF
--- a/client/app/components/homepage/TripsDisplayComponent.js
+++ b/client/app/components/homepage/TripsDisplayComponent.js
@@ -109,7 +109,7 @@ const TripsDisplayComponent = ({ trips, userId, homeCurrency }) => {
 
     return (
         <div className="trips-display">
-            <div className="row" style={{ display: 'flex', justifyContent: 'space-between', width: '100%', marginTop:"-30px" }}>
+            <div className="row" style={{ display: 'flex', justifyContent: 'space-between', width: '100%', marginTop:"-40px" }}>
                 <div className="col">
                     <h1>View Your Trips:</h1>
                 </div>

--- a/client/app/components/singletrip/BarGraphComponent.js
+++ b/client/app/components/singletrip/BarGraphComponent.js
@@ -2,19 +2,17 @@
 import React, { useState, useEffect } from 'react';
 import { BarChart } from '@mui/x-charts/BarChart';
 import dayjs from 'dayjs';
-import currencySymbolMap from 'currency-symbol-map';
 import LoadingPageComponent from '../LoadingPageComponent';
-import { load } from 'ol/Image';
 import "../../css/barChart.css";
 
-const BarGraphComponent = ({ tripData, expensesToDisplay, categoryData, currency }) => {
+const BarGraphComponent = ({ tripData, expensesToDisplay, categoryData }) => {
     const [loading, setLoading] = React.useState(true);
     const [loadingTimedOut, setLoadingTimedOut] = useState(false);
 
     useEffect(() => {
         const timeoutId = setTimeout(() => {
             if (loading) {
-                setLoadingTimedOut(true); 
+                setLoadingTimedOut(true);
             }
         }, 5000); // 5 seconds
 
@@ -26,20 +24,9 @@ const BarGraphComponent = ({ tripData, expensesToDisplay, categoryData, currency
             setLoading(false);
         }
         if (expensesToDisplay && categoryData && categoryData.datasets.length > 0) {
-            setLoading(false); 
+            setLoading(false);
         }
     }, [expensesToDisplay, categoryData]);
-
-    const currencySymbol = currencySymbolMap(currency);
-
-    const formatDate = (dateStr) => {
-        const [year, month, day] = dateStr.split('-');
-        const formattedDate = new Intl.DateTimeFormat('en-US', { month: 'long', day: 'numeric' }).format(
-            new Date(year, month - 1, day)
-        );
-        
-        return formattedDate;
-    }
 
     const generateDateArray = (startDate, endDate) => {
         const start = dayjs(startDate);
@@ -48,7 +35,7 @@ const BarGraphComponent = ({ tripData, expensesToDisplay, categoryData, currency
 
         // loop through the dates from the start to the end date and add each date in between (inclusive)
         for (let date = start; date.isBefore(end.add(1, 'day')); date = date.add(1, 'day')) {
-            datesArray.push(formatDate(date.format('YYYY-MM-DD')));
+            datesArray.push(date.format('YYYY-MM-DD'));
         }
 
         return datesArray;
@@ -72,7 +59,7 @@ const BarGraphComponent = ({ tripData, expensesToDisplay, categoryData, currency
         'Other': 'leisure',
     };
     expensesToDisplay.forEach(expense => {
-        const date = formatDate(dayjs(expense.posted).format('YYYY-MM-DD'));
+        const date = dayjs(expense.posted).format('YYYY-MM-DD');
         const category = expense.category;
         const amount = parseFloat(expense.amount);
 
@@ -110,7 +97,7 @@ const BarGraphComponent = ({ tripData, expensesToDisplay, categoryData, currency
             stack: categoryStackMap[category],
         };
     });
-    
+
     const chartColors = categoryData?.datasets?.[0]?.backgroundColor || ['#000'];
 
     if (loading && !loadingTimedOut) {
@@ -147,7 +134,7 @@ const BarGraphComponent = ({ tripData, expensesToDisplay, categoryData, currency
                     }
                 }}
                 style={{
-                    maxWidth: '100%', 
+                    maxWidth: '100%',
                     display: 'block',
                 }}
             />

--- a/client/app/css/homepage.css
+++ b/client/app/css/homepage.css
@@ -13,6 +13,13 @@
     font-weight: bold;
 }
 
+.welcome-content {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 165%;
+}
+
 .logout {
     background-color: var(--lightgreen);
     color: white;

--- a/client/app/css/tripsDisplay.css
+++ b/client/app/css/tripsDisplay.css
@@ -51,7 +51,7 @@
 
 .search-bar {
     width: 100%;
-    margin-top: 20px;
+    margin-top: -20px;
     margin-bottom: 20px;
 }
 

--- a/client/app/homepage/page.js
+++ b/client/app/homepage/page.js
@@ -183,7 +183,7 @@ function homepage() {
 
     useEffect(() => {
         if (userId && trips.length >= 0 && allTripLocations.length >= 0) {
-            setLoading(false); 
+            setLoading(false);
         }
     }, [userId, trips, allTripLocations]);
 
@@ -195,53 +195,53 @@ function homepage() {
         <GoogleOAuthProvider clientId={googleID}>
             <ToastContainer />
             {loading ? (
-                <LoadingPageComponent /> 
+                <LoadingPageComponent />
             ) : (
-            <div>
-                {/* Home Currency Popup */}
-                <HomeCurrencyPopupComponent
-                    isOpen={isPopupOpen}
-                    onClose={handleClosePopup}
-                    userId={userId}
-                />
-                {/* Header section */}
-                <HeaderComponent
-                    headerTitle="Trip Trends"
-                    setUserName={setUserName}
-                    userId={userId}
-                />
-                <div className='main-container'>
-                    {/* Welcome section */}
-                    <div className="welcome-section">
-                        {userName ?
-                            (
-                                <h1 style={{ textAlign: "center" }}>Welcome, {userName}!</h1>
-                            ) :
-                            (
-                                <h1 style={{ textAlign: "center" }}>Welcome!</h1>
-                        )}
-                        <PlaidButtonComponent />
-                        <p style={{marginLeft: '-15px'}}>See where you've been:</p>
-                    </div>
-
-                    <div className="responsive-container" style={{ display: 'flex', justifyContent: 'space-between' }}>
-                        {/* Map section */}
-                        <MapComponent allTripLocations={allTripLocations} toggleTripDetails={toggleTripDetails} />
-                        {/* Recent Trips section */}
-                        <div style={{ width: '35%', marginLeft: '10px' }}>
-                            <RecentTripsComponent trips={trips} />
+                <div>
+                    {/* Home Currency Popup */}
+                    <HomeCurrencyPopupComponent
+                        isOpen={isPopupOpen}
+                        onClose={handleClosePopup}
+                        userId={userId}
+                    />
+                    {/* Header section */}
+                    <HeaderComponent
+                        headerTitle="Trip Trends"
+                        setUserName={setUserName}
+                        userId={userId}
+                    />
+                    <div className='main-container'>
+                        {/* Welcome section */}
+                        <div className="welcome-section">
+                            <div className="welcome-content">
+                                {userName ? (
+                                    <h1>Welcome, {userName}!</h1>
+                                ) : (
+                                    <h1>Welcome!</h1>
+                                )}
+                                <PlaidButtonComponent />
+                            </div>
+                            <p>See where you've been:</p>
                         </div>
-                    </div>
 
-                {/* All Trips Section */}
-                <TripsDisplayComponent trips={trips} userId={userId} homeCurrency={homeCurrency}/>
+                        <div className="responsive-container" style={{ display: 'flex', justifyContent: 'space-between' }}>
+                            {/* Map section */}
+                            <MapComponent allTripLocations={allTripLocations} toggleTripDetails={toggleTripDetails} />
+                            {/* Recent Trips section */}
+                            <div style={{ width: '35%', marginLeft: '10px' }}>
+                                <RecentTripsComponent trips={trips} />
+                            </div>
+                        </div>
+
+                        {/* All Trips Section */}
+                        <TripsDisplayComponent trips={trips} userId={userId} homeCurrency={homeCurrency} />
                         {/* All Trips Section */}
                         {/* <TripsDisplayComponent trips={trips} userId={userId} /> */}
 
+                    </div>
                 </div>
-            </div>
-        )}
-        
+            )}
+
         </GoogleOAuthProvider>
     );
 }

--- a/client/app/singletrip/page.js
+++ b/client/app/singletrip/page.js
@@ -278,7 +278,7 @@ function Singletrip() {
 
     const applyCategoryFilter = () => {
         let filteredData = [];
-        
+
         if (selectedCategory) {
             originalData.data.forEach((expense) => {
                 if (expense.category === selectedCategory) {
@@ -663,216 +663,98 @@ function Singletrip() {
                 userId={userId}
             />
             <div className="trip-pg-contanier">
-            <div className="main-container">
-                {tripData ? (
-                    <div>
-                        <NavBarComponent
-                            tripId={tripId}
-                            userRole={userRole}
-                            tripName={tripName}
-                        />
-                        <div className="container">
-                            {/* Icon Bar Above Trip Info */}
-                            <TripIconBarComponent
+                <div className="main-container">
+                    {tripData ? (
+                        <div>
+                            <NavBarComponent
                                 tripId={tripId}
-                                userId={userId}
-                                isOwner={isOwner}
-                                tripData={tripData}
-                                tripLocations={tripLocations}
                                 userRole={userRole}
-                                fetchTripData={fetchTripData}
-                                homeCurrency={homeCurrency} // budget is always set as home
+                                tripName={tripName}
                             />
-                            <CurrencyToggleComponent
-                                homeCurrency={homeCurrency}
-                                otherCurrencies={otherCurrencies}
-                                toggleChange={handleCurrencyToggleChange}
-                            />
-                            {/* General Trip Info*/}
-                            <GeneralTripInfoComponent
-                                userId={userId}
-                                tripData={tripData} // handles budget currency
-                                convertedBudget={convertedBudget}
-                                tripId={tripId}
-                                tripLocations={tripLocations}
-                                expenses={expenseUSD}
-                                totalExpenses={
-                                    selectedToggleCurrency !== ""
-                                        ? totalExpensesInToggleCurrency
-                                        : totalExpenses
-                                }
-                                currency={
-                                    selectedToggleCurrency !== ""
-                                        ? selectedToggleCurrency
-                                        : homeCurrency
-                                }
-                            />
-                        </div>
-                        <br></br>
-                        <div className="container">
-                            <div className="row">
-                                <div
-                                    className="col"
-                                    style={{ flexDirection: "column" }}
-                                >
-                                    <h2
-                                        style={{
-                                            textAlign: "center",
-                                            marginBottom: "20px",
-                                            marginTop: "15px",
-                                        }}
-                                    >
-                                        Exchange Rates
-                                    </h2>
-                                    {/* Exchange Rate Table */}
-                                    <ExchangeRateTableComponent
-                                        exchangeRates={exchangeRates}
-                                        currencyCodes={currencyCodes}
-                                        homeCurrency={homeCurrency}
-                                    />
-                                </div>
-                                <div
-                                    className="col"
-                                    style={{ flexDirection: "column" }}
-                                >
-                                    <h2
-                                        style={{
-                                            textAlign: "center",
-                                            marginTop: "30px",
-                                            marginBottom: "20px",
-                                        }}
-                                    >
-                                        Expenses in{" "}
-                                        {selectedToggleCurrency !== ""
+                            <div className="container">
+                                {/* Icon Bar Above Trip Info */}
+                                <TripIconBarComponent
+                                    tripId={tripId}
+                                    userId={userId}
+                                    isOwner={isOwner}
+                                    tripData={tripData}
+                                    tripLocations={tripLocations}
+                                    userRole={userRole}
+                                    fetchTripData={fetchTripData}
+                                    homeCurrency={homeCurrency} // budget is always set as home
+                                />
+                                <CurrencyToggleComponent
+                                    homeCurrency={homeCurrency}
+                                    otherCurrencies={otherCurrencies}
+                                    toggleChange={handleCurrencyToggleChange}
+                                />
+                                {/* General Trip Info*/}
+                                <GeneralTripInfoComponent
+                                    userId={userId}
+                                    tripData={tripData} // handles budget currency
+                                    convertedBudget={convertedBudget}
+                                    tripId={tripId}
+                                    tripLocations={tripLocations}
+                                    expenses={expenseUSD}
+                                    totalExpenses={
+                                        selectedToggleCurrency !== ""
+                                            ? totalExpensesInToggleCurrency
+                                            : totalExpenses
+                                    }
+                                    currency={
+                                        selectedToggleCurrency !== ""
                                             ? selectedToggleCurrency
-                                            : homeCurrency}
-                                    </h2>
-                                    <SpendingCirclesComponent
-                                        totalExpenses={
-                                            selectedToggleCurrency !== ""
-                                                ? totalExpensesInToggleCurrency
-                                                : totalExpenses
-                                        }
-                                        tripData={tripData}
-                                        convertedBudget={convertedBudget}
-                                        currency={
-                                            selectedToggleCurrency !== ""
-                                                ? selectedToggleCurrency
-                                                : homeCurrency
-                                        }
-                                    />
-                                </div>
+                                            : homeCurrency
+                                    }
+                                />
                             </div>
-                        </div>
-                        {/* Data Visualisations Toggle */}
-                        <div className="toggle-container">
-                            <div className="row justify-content-center">
-                                <div className="col-auto">
+                            <br></br>
+                            <div className="container">
+                                <div className="row">
                                     <div
-                                        className="icon-div toggle-icon"
-                                        tabIndex="0"
-                                        onClick={toggleVisibility}
+                                        className="col"
+                                        style={{ flexDirection: "column" }}
                                     >
-                                        <div className="icon-SVG">
-                                            {isVisible ? (
-                                                <svg
-                                                    xmlns="http://www.w3.org/2000/svg"
-                                                    fill="none"
-                                                    viewBox="0 0 24 24"
-                                                    strokeWidth="1.3"
-                                                    stroke="currentColor"
-                                                    className="size-6"
-                                                >
-                                                    <path
-                                                        strokeLinecap="round"
-                                                        strokeLinejoin="round"
-                                                        d="m4.5 18.75 7.5-7.5 7.5 7.5"
-                                                    />
-                                                    <path
-                                                        strokeLinecap="round"
-                                                        strokeLinejoin="round"
-                                                        d="m4.5 12.75 7.5-7.5 7.5 7.5"
-                                                    />
-                                                </svg>
-                                            ) : (
-                                                <svg
-                                                    xmlns="http://www.w3.org/2000/svg"
-                                                    fill="none"
-                                                    viewBox="0 0 24 24"
-                                                    strokeWidth="1.3"
-                                                    stroke="currentColor"
-                                                    className="size-6"
-                                                >
-                                                    <path
-                                                        strokeLinecap="round"
-                                                        strokeLinejoin="round"
-                                                        d="m4.5 5.25 7.5 7.5 7.5-7.5m-15 6 7.5 7.5 7.5-7.5"
-                                                    />
-                                                </svg>
-                                            )}
-                                            <span className="icon-text">
-                                                {isVisible
-                                                    ? "Hide Visualizations"
-                                                    : "Show Visualizations"}
-                                            </span>
-                                        </div>
+                                        <h2
+                                            style={{
+                                                textAlign: "center",
+                                                marginBottom: "20px",
+                                                marginTop: "15px",
+                                            }}
+                                        >
+                                            Exchange Rates
+                                        </h2>
+                                        {/* Exchange Rate Table */}
+                                        <ExchangeRateTableComponent
+                                            exchangeRates={exchangeRates}
+                                            currencyCodes={currencyCodes}
+                                            homeCurrency={homeCurrency}
+                                        />
                                     </div>
-                                </div>
-                            </div>
-                            {isVisible && (
-                                <>
-                                    <div className="row">
-                                        {/* Budget Meter */}
-                                        <div className="col">
-                                            <div className="meter-container">
-                                                <BudgetMeterComponent
-                                                    tripData={tripData}
-                                                    convertedBudget={
-                                                        convertedBudget
-                                                    }
-                                                    expensesToDisplay={
-                                                        expensesToDisplay
-                                                    }
-                                                    totalExpenses={
-                                                        selectedToggleCurrency !==
-                                                            ""
-                                                            ? totalExpensesInToggleCurrency
-                                                            : totalExpenses
-                                                    }
-                                                    currency={
-                                                        selectedToggleCurrency !==
-                                                            ""
-                                                            ? selectedToggleCurrency
-                                                            : homeCurrency
-                                                    }
-                                                />
-                                            </div>
-                                        </div>
-                                        {/* Pie Chart */}
-                                        <div className="col">
-                                            <div className="meter-container">
-                                                <CategoryDataComponent
-                                                    categoryData={categoryData}
-                                                    currency={
-                                                        selectedToggleCurrency !==
-                                                            ""
-                                                            ? selectedToggleCurrency
-                                                            : homeCurrency
-                                                    }
-                                                />
-                                            </div>
-                                        </div>
-                                    </div>
-                                    {/* Bar Graph */}
-                                    <div className="meter-container">
-                                        <BarGraphComponent
-                                            tripData={tripData}
-                                            expensesToDisplay={
+                                    <div
+                                        className="col"
+                                        style={{ flexDirection: "column" }}
+                                    >
+                                        <h2
+                                            style={{
+                                                textAlign: "center",
+                                                marginTop: "30px",
+                                                marginBottom: "20px",
+                                            }}
+                                        >
+                                            Expenses in{" "}
+                                            {selectedToggleCurrency !== ""
+                                                ? selectedToggleCurrency
+                                                : homeCurrency}
+                                        </h2>
+                                        <SpendingCirclesComponent
+                                            totalExpenses={
                                                 selectedToggleCurrency !== ""
-                                                    ? expensesToDisplay
-                                                    : convertedHomeCurrencyExpenseData
+                                                    ? totalExpensesInToggleCurrency
+                                                    : totalExpenses
                                             }
-                                            categoryData={categoryData}
+                                            tripData={tripData}
+                                            convertedBudget={convertedBudget}
                                             currency={
                                                 selectedToggleCurrency !== ""
                                                     ? selectedToggleCurrency
@@ -880,25 +762,181 @@ function Singletrip() {
                                             }
                                         />
                                     </div>
-                                </>
-                            )}
-                        </div>
-                        {/* Icon Bar Above Expenses */}
-                        <div>
-                            <header className="icon-bar-header">
-                                <div class="icon-bar-left">
-                                    {userRole == "owner" ||
-                                        userRole == "editor" ? (
-                                        // {/* Add Expense Button */}
+                                </div>
+                            </div>
+                            {/* Data Visualisations Toggle */}
+                            <div className="toggle-container">
+                                <div className="row justify-content-center">
+                                    <div className="col-auto">
+                                        <div
+                                            className="icon-div toggle-icon"
+                                            tabIndex="0"
+                                            onClick={toggleVisibility}
+                                        >
+                                            <div className="icon-SVG">
+                                                {isVisible ? (
+                                                    <svg
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                        fill="none"
+                                                        viewBox="0 0 24 24"
+                                                        strokeWidth="1.3"
+                                                        stroke="currentColor"
+                                                        className="size-6"
+                                                    >
+                                                        <path
+                                                            strokeLinecap="round"
+                                                            strokeLinejoin="round"
+                                                            d="m4.5 18.75 7.5-7.5 7.5 7.5"
+                                                        />
+                                                        <path
+                                                            strokeLinecap="round"
+                                                            strokeLinejoin="round"
+                                                            d="m4.5 12.75 7.5-7.5 7.5 7.5"
+                                                        />
+                                                    </svg>
+                                                ) : (
+                                                    <svg
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                        fill="none"
+                                                        viewBox="0 0 24 24"
+                                                        strokeWidth="1.3"
+                                                        stroke="currentColor"
+                                                        className="size-6"
+                                                    >
+                                                        <path
+                                                            strokeLinecap="round"
+                                                            strokeLinejoin="round"
+                                                            d="m4.5 5.25 7.5 7.5 7.5-7.5m-15 6 7.5 7.5 7.5-7.5"
+                                                        />
+                                                    </svg>
+                                                )}
+                                                <span className="icon-text">
+                                                    {isVisible
+                                                        ? "Hide Visualizations"
+                                                        : "Show Visualizations"}
+                                                </span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                {isVisible && (
+                                    <>
+                                        <div className="row">
+                                            {/* Budget Meter */}
+                                            <div className="col">
+                                                <div className="meter-container">
+                                                    <BudgetMeterComponent
+                                                        tripData={tripData}
+                                                        convertedBudget={
+                                                            convertedBudget
+                                                        }
+                                                        expensesToDisplay={
+                                                            expensesToDisplay
+                                                        }
+                                                        totalExpenses={
+                                                            selectedToggleCurrency !==
+                                                                ""
+                                                                ? totalExpensesInToggleCurrency
+                                                                : totalExpenses
+                                                        }
+                                                        currency={
+                                                            selectedToggleCurrency !==
+                                                                ""
+                                                                ? selectedToggleCurrency
+                                                                : homeCurrency
+                                                        }
+                                                    />
+                                                </div>
+                                            </div>
+                                            {/* Pie Chart */}
+                                            <div className="col">
+                                                <div className="meter-container">
+                                                    <CategoryDataComponent
+                                                        categoryData={categoryData}
+                                                        currency={
+                                                            selectedToggleCurrency !==
+                                                                ""
+                                                                ? selectedToggleCurrency
+                                                                : homeCurrency
+                                                        }
+                                                    />
+                                                </div>
+                                            </div>
+                                        </div>
+                                        {/* Bar Graph */}
+                                        <div className="meter-container">
+                                            <BarGraphComponent tripData={tripData} expensesToDisplay={convertedHomeCurrencyExpenseData} categoryData={categoryData} />
+                                        </div>
+                                    </>
+                                )}
+                            </div>
+                            {/* Icon Bar Above Expenses */}
+                            <div>
+                                <header className="icon-bar-header">
+                                    <div class="icon-bar-left">
+                                        {userRole == "owner" ||
+                                            userRole == "editor" ? (
+                                            // {/* Add Expense Button */}
+                                            <div
+                                                className="icon-div"
+                                                tooltip="Add Expense"
+                                                tabIndex="0"
+                                            >
+                                                <div className="icon-SVG">
+                                                    <svg
+                                                        onClick={() =>
+                                                            setPopUpVisible(true)
+                                                        }
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                        fill="none"
+                                                        viewBox="0 0 24 24"
+                                                        strokeWidth="1.3"
+                                                        stroke="currentColor"
+                                                        className="size-6"
+                                                    >
+                                                        <path
+                                                            strokeLinecap="round"
+                                                            strokeLinejoin="round"
+                                                            d="M12 9v6m3-3H9m12 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+                                                        />
+                                                    </svg>
+                                                    <span className="icon-text">
+                                                        Add Expense
+                                                    </span>
+                                                </div>
+                                            </div>
+                                        ) : null}
+                                        {/* Download Trip Button */}
+                                        <DownloadTripComponent
+                                            tripData={tripData}
+                                            tripId={tripId}
+                                        />
+                                    </div>
+                                    <div className="icon-bar-center">
+                                        <h2>Expense History</h2>
+                                    </div>
+                                    <div class="icon-bar-right">
+                                        {/* Filter Expenses Button */}
+                                        {selectedFilter && (
+                                            <div className="applied-filter">
+                                                <span style={{ paddingLeft: "29px" }}>{`Filter: ${selectedFilter}`}</span>
+                                                <button
+                                                    className="clear-filter-btn"
+                                                    onClick={clearFilter}
+                                                >
+                                                    &times;
+                                                </button>
+                                            </div>
+                                        )}
                                         <div
                                             className="icon-div"
-                                            tooltip="Add Expense"
+                                            tooltip="Filter"
                                             tabIndex="0"
                                         >
                                             <div className="icon-SVG">
                                                 <svg
                                                     onClick={() =>
-                                                        setPopUpVisible(true)
+                                                        setFilterPopupVisible(true)
                                                     }
                                                     xmlns="http://www.w3.org/2000/svg"
                                                     fill="none"
@@ -910,211 +948,160 @@ function Singletrip() {
                                                     <path
                                                         strokeLinecap="round"
                                                         strokeLinejoin="round"
-                                                        d="M12 9v6m3-3H9m12 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+                                                        d="M12 3c2.755 0 5.455.232 8.083.678.533.09.917.556.917 1.096v1.044a2.25 2.25 0 0 1-.659 1.591l-5.432 5.432a2.25 2.25 0 0 0-.659 1.591v2.927a2.25 2.25 0 0 1-1.244 2.013L9.75 21v-6.568a2.25 2.25 0 0 0-.659-1.591L3.659 7.409A2.25 2.25 0 0 1 3 5.818V4.774c0-.54.384-1.006.917-1.096A48.32 48.32 0 0 1 12 3Z"
                                                     />
                                                 </svg>
                                                 <span className="icon-text">
-                                                    Add Expense
+                                                    Filter
                                                 </span>
                                             </div>
                                         </div>
-                                    ) : null}
-                                    {/* Download Trip Button */}
-                                    <DownloadTripComponent
+                                    </div>
+                                </header>
+                            </div>
+                            <div className="container">
+                                <div
+                                    className="row"
+                                    style={{
+                                        justifyContent: "center",
+                                        alignItems: "center",
+                                        display: "flex",
+                                        textAlign: "center",
+                                    }}
+                                >
+                                    {/* Expense Table */}
+                                    <ExpenseTableComponent
                                         tripData={tripData}
                                         tripId={tripId}
+                                        tripLocations={tripLocations}
+                                        expensesToDisplay={expensesToDisplay}
+                                        currencyCodes={currencyCodes}
+                                        expenseCategories={expenseCategories}
+                                        userRole={userRole}
+                                        categoryData={categoryData}
+                                        selectedCurrency={selectedCurrency}
+                                        setSelectedCurrency={setSelectedCurrency}
+                                        otherCurrencies={otherCurrencies}
                                     />
                                 </div>
-                                <div className="icon-bar-center">
-                                    <h2>Expense History</h2>
-                                </div>
-                                <div class="icon-bar-right">
-                                    {/* Filter Expenses Button */}
-                                    {selectedFilter && (
-                                        <div className="applied-filter">
-                                            <span style={{ paddingLeft: "29px" }}>{`Filter: ${selectedFilter}`}</span>
-                                            <button
-                                                className="clear-filter-btn"
-                                                onClick={clearFilter}
-                                            >
-                                                &times;
-                                            </button>
-                                        </div>
-                                    )}
-                                    <div
-                                        className="icon-div"
-                                        tooltip="Filter"
-                                        tabIndex="0"
-                                    >
-                                        <div className="icon-SVG">
-                                            <svg
-                                                onClick={() =>
-                                                    setFilterPopupVisible(true)
-                                                }
-                                                xmlns="http://www.w3.org/2000/svg"
-                                                fill="none"
-                                                viewBox="0 0 24 24"
-                                                strokeWidth="1.3"
-                                                stroke="currentColor"
-                                                className="size-6"
-                                            >
-                                                <path
-                                                    strokeLinecap="round"
-                                                    strokeLinejoin="round"
-                                                    d="M12 3c2.755 0 5.455.232 8.083.678.533.09.917.556.917 1.096v1.044a2.25 2.25 0 0 1-.659 1.591l-5.432 5.432a2.25 2.25 0 0 0-.659 1.591v2.927a2.25 2.25 0 0 1-1.244 2.013L9.75 21v-6.568a2.25 2.25 0 0 0-.659-1.591L3.659 7.409A2.25 2.25 0 0 1 3 5.818V4.774c0-.54.384-1.006.917-1.096A48.32 48.32 0 0 1 12 3Z"
-                                                />
-                                            </svg>
-                                            <span className="icon-text">
-                                                Filter
-                                            </span>
-                                        </div>
-                                    </div>
-                                </div>
-                            </header>
-                        </div>
-                        <div className="container">
-                            <div
-                                className="row"
-                                style={{
-                                    justifyContent: "center",
-                                    alignItems: "center",
-                                    display: "flex",
-                                    textAlign: "center",
-                                }}
-                            >
-                                {/* Expense Table */}
-                                <ExpenseTableComponent
-                                    tripData={tripData}
-                                    tripId={tripId}
-                                    tripLocations={tripLocations}
-                                    expensesToDisplay={expensesToDisplay}
-                                    currencyCodes={currencyCodes}
-                                    expenseCategories={expenseCategories}
-                                    userRole={userRole}
-                                    categoryData={categoryData}
-                                    selectedCurrency={selectedCurrency}
-                                    setSelectedCurrency={setSelectedCurrency}
-                                    otherCurrencies={otherCurrencies}
-                                />
-                            </div>
-                            <br></br>
-                            <br></br>
-                            <br></br>
-                        </div>
-                    </div>
-                ) : (
-                    <LoadingPageComponent />
-                )}
-                {/* Suggested Expenses */}
-                <ExpenseSuggestionsComponent
-                    userId={userId}
-                    currentTripId={tripId}
-                    onTransferSuccess={handleExpenseTransferSuccess}
-                />
-
-                {/* Create a expense popup form */}
-                <ExpenseFormComponent
-                    tripId={tripId}
-                    newExpenseData={newExpenseData}
-                    setNewExpenseData={setNewExpenseData}
-                    selectedCurrency={selectedCurrency}
-                    setSelectedCurrency={setSelectedCurrency}
-                    submitNewExpense={submitNewExpense}
-                    isPopUpVisible={isPopUpVisible}
-                    setPopUpVisible={setPopUpVisible}
-                    otherCurrencies={otherCurrencies}
-                    currencyCodes={currencyCodes}
-                    expenseCategories={expenseCategories}
-                />
-                {/* Create a filter popup form */}
-                <div className="filter-container">
-                    {isFilterPopupVisible && (
-                        <div className="filter-popup">
-                            <div className="filter-popup-content">
-                                <span
-                                    className="filter-popup-close"
-                                    onClick={() => setFilterPopupVisible(false)}
-                                >
-                                    &times;
-                                </span>
-                                <h2 className="filter-popup-title">
-                                    Filter Expenses
-                                </h2>
-                                <div className="filter-options">
-                                    <button
-                                        className="filter-option-button"
-                                        onClick={() =>
-                                            handleFilterChange("highest")
-                                        }
-                                    >
-                                        Highest to Lowest
-                                    </button>
-                                    <button
-                                        className="filter-option-button"
-                                        onClick={() =>
-                                            handleFilterChange("lowest")
-                                        }
-                                    >
-                                        Lowest to Highest
-                                    </button>
-                                    <button
-                                        className="filter-option-button"
-                                        onClick={() =>
-                                            handleFilterChange("recent")
-                                        }
-                                    >
-                                        Most Recent
-                                    </button>
-                                    <button
-                                        className="filter-option-button"
-                                        onClick={() =>
-                                            handleFilterChange("oldest")
-                                        }
-                                    >
-                                        Oldest
-                                    </button>
-                                    <div className="filter-option-button">
-                                        <label
-                                            htmlFor="category"
-                                            onClick={toggleDropdown}
-                                            style={{ cursor: "pointer" }}
-                                        >
-                                            Select Category
-                                        </label>
-                                        {isDropdownVisible && (
-                                            <div className="custom-dropdown">
-                                                <div
-                                                    className="dropdown-item"
-                                                    onClick={
-                                                        handleAllCategoriesSelect
-                                                    }
-                                                >
-                                                    All Categories
-                                                </div>
-                                                {expenseCategories.map(
-                                                    (category) => (
-                                                        <div
-                                                            key={category}
-                                                            className="dropdown-item"
-                                                            onClick={() =>
-                                                                handleCategorySelect(
-                                                                    category
-                                                                )
-                                                            }
-                                                        >
-                                                            {category}
-                                                        </div>
-                                                    )
-                                                )}
-                                            </div>
-                                        )}
-                                    </div>
-                                </div>
+                                <br></br>
+                                <br></br>
+                                <br></br>
                             </div>
                         </div>
+                    ) : (
+                        <LoadingPageComponent />
                     )}
+                    {/* Suggested Expenses */}
+                    <ExpenseSuggestionsComponent
+                        userId={userId}
+                        currentTripId={tripId}
+                        onTransferSuccess={handleExpenseTransferSuccess}
+                    />
+
+                    {/* Create a expense popup form */}
+                    <ExpenseFormComponent
+                        tripId={tripId}
+                        newExpenseData={newExpenseData}
+                        setNewExpenseData={setNewExpenseData}
+                        selectedCurrency={selectedCurrency}
+                        setSelectedCurrency={setSelectedCurrency}
+                        submitNewExpense={submitNewExpense}
+                        isPopUpVisible={isPopUpVisible}
+                        setPopUpVisible={setPopUpVisible}
+                        otherCurrencies={otherCurrencies}
+                        currencyCodes={currencyCodes}
+                        expenseCategories={expenseCategories}
+                    />
+                    {/* Create a filter popup form */}
+                    <div className="filter-container">
+                        {isFilterPopupVisible && (
+                            <div className="filter-popup">
+                                <div className="filter-popup-content">
+                                    <span
+                                        className="filter-popup-close"
+                                        onClick={() => setFilterPopupVisible(false)}
+                                    >
+                                        &times;
+                                    </span>
+                                    <h2 className="filter-popup-title">
+                                        Filter Expenses
+                                    </h2>
+                                    <div className="filter-options">
+                                        <button
+                                            className="filter-option-button"
+                                            onClick={() =>
+                                                handleFilterChange("highest")
+                                            }
+                                        >
+                                            Highest to Lowest
+                                        </button>
+                                        <button
+                                            className="filter-option-button"
+                                            onClick={() =>
+                                                handleFilterChange("lowest")
+                                            }
+                                        >
+                                            Lowest to Highest
+                                        </button>
+                                        <button
+                                            className="filter-option-button"
+                                            onClick={() =>
+                                                handleFilterChange("recent")
+                                            }
+                                        >
+                                            Most Recent
+                                        </button>
+                                        <button
+                                            className="filter-option-button"
+                                            onClick={() =>
+                                                handleFilterChange("oldest")
+                                            }
+                                        >
+                                            Oldest
+                                        </button>
+                                        <div className="filter-option-button">
+                                            <label
+                                                htmlFor="category"
+                                                onClick={toggleDropdown}
+                                                style={{ cursor: "pointer" }}
+                                            >
+                                                Select Category
+                                            </label>
+                                            {isDropdownVisible && (
+                                                <div className="custom-dropdown">
+                                                    <div
+                                                        className="dropdown-item"
+                                                        onClick={
+                                                            handleAllCategoriesSelect
+                                                        }
+                                                    >
+                                                        All Categories
+                                                    </div>
+                                                    {expenseCategories.map(
+                                                        (category) => (
+                                                            <div
+                                                                key={category}
+                                                                className="dropdown-item"
+                                                                onClick={() =>
+                                                                    handleCategorySelect(
+                                                                        category
+                                                                    )
+                                                                }
+                                                            >
+                                                                {category}
+                                                            </div>
+                                                        )
+                                                    )}
+                                                </div>
+                                            )}
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        )}
+                    </div>
                 </div>
-            </div>
             </div>
             <div></div>
         </div>


### PR DESCRIPTION
## Description
- The purpose of this PR is to fix the Bar Graph, and clean up the Homepage UI by removing white space and moving the Plaid button.
- This PR belongs to ticket #326 and #327 
- Modified `BarGraphComponent.js`, `singletrip/page.js`, `homepage/page.js`, `homepage.css`, `TripsDisplayComponent.js`, and `tripsDisplay.css`

## What’s in this change?
- `BarGraphComponent.js`
  - Removed the formatted dates because this interfered with mapping expenses to their correct date.
- `singletrip/page.js`
  - Removed passing in unneeded parameters to the `Bar Graph Component`
- `homepage/page.js`
  - Moved the "Link Bank Account" button to be on the right side of the screen.
- `homepage.css`
  - Added styling to move the button
-  `TripsDisplayComponent.js`
   - Removed extra white space above "View All Trips"
- `tripsDisplay.css`
  - Removed extra white space around the search bar.

## Testing Changes
- Unit test coverage report below
- Tested the bar graph on different trips

## Homepage Before
<img width="1440" alt="before1" src="https://github.com/user-attachments/assets/691589c8-0113-480a-a147-656f060470af">
<img width="1438" alt="before2" src="https://github.com/user-attachments/assets/e6f8bee9-430c-44f2-acca-867c93f0919c">

## Homepage After
<img width="1440" alt="After1" src="https://github.com/user-attachments/assets/93530254-4ca5-4a91-98c0-826a1d04846b">
<img width="1440" alt="After2" src="https://github.com/user-attachments/assets/3c848953-fe18-4330-8dcc-b149fa50f2a9">

## Bar Graph Before
<img width="1178" alt="bargraphBefore" src="https://github.com/user-attachments/assets/ed1afd55-6921-4c23-95e5-b8dda71318d3">

## Bar Graph After
<img width="1185" alt="bargraphAfter" src="https://github.com/user-attachments/assets/4378c934-78f1-4c4b-bd41-bc4414264080">

