### PR TITLE
Update receipt styling + styling changes for consistency

### DIFF
--- a/client/app/components/homepage/PlaidButtonComponent.js
+++ b/client/app/components/homepage/PlaidButtonComponent.js
@@ -237,15 +237,17 @@ const PlaidLinkComponent = ({ onSuccess }) => {
             ) : error ? (
                 <div className="error-message">{error}</div>
             ) : accessToken ? (
-                <div>
+                <div className="plaid-link-button-wrapper">
                     <button
                         className="plaid-link-button"
                         onClick={resetPlaidConnection}
                     >
                         
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="size-6" width="20" height="20">
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M13.181 8.68a4.503 4.503 0 0 1 1.903 6.405m-9.768-2.782L3.56 14.06a4.5 4.5 0 0 0 6.364 6.365l3.129-3.129m5.614-5.615 1.757-1.757a4.5 4.5 0 0 0-6.364-6.365l-4.5 4.5c-.258.26-.479.541-.661.84m1.903 6.405a4.495 4.495 0 0 1-1.242-.88 4.483 4.483 0 0 1-1.062-1.683m6.587 2.345 5.907 5.907m-5.907-5.907L8.898 8.898M2.991 2.99 8.898 8.9" />
-                    </svg> <br></br>
+                        <div style={{ display: 'inline-flex', marginRight: '5px', alignItems: 'center' }}>
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 26 25" strokeWidth="1.5" stroke="currentColor" className="size-6" width="20" height="20">
+                                <path strokeLinecap="round" strokeLinejoin="round" d="M13.181 8.68a4.503 4.503 0 0 1 1.903 6.405m-9.768-2.782L3.56 14.06a4.5 4.5 0 0 0 6.364 6.365l3.129-3.129m5.614-5.615 1.757-1.757a4.5 4.5 0 0 0-6.364-6.365l-4.5 4.5c-.258.26-.479.541-.661.84m1.903 6.405a4.495 4.495 0 0 1-1.242-.88 4.483 4.483 0 0 1-1.062-1.683m6.587 2.345 5.907 5.907m-5.907-5.907L8.898 8.898M2.991 2.99 8.898 8.9" />
+                            </svg> 
+                        </div>
                         Unlink Bank
                     </button>
                 </div>
@@ -259,9 +261,11 @@ const PlaidLinkComponent = ({ onSuccess }) => {
                             console.log("Plaid Link Exit:", error, metadata)
                         }
                     >
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="size-6" width="20" height="20">
-                                <path strokeLinecap="round" strokeLinejoin="round" d="M13.19 8.688a4.5 4.5 0 0 1 1.242 7.244l-4.5 4.5a4.5 4.5 0 0 1-6.364-6.364l1.757-1.757m13.35-.622 1.757-1.757a4.5 4.5 0 0 0-6.364-6.364l-4.5 4.5a4.5 4.5 0 0 0 1.242 7.244" />
+                        <div style={{ display: 'inline-flex', marginRight: '5px', alignItems: 'center' }}>
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 26 25" strokeWidth="1.3" stroke="currentColor" className="size-6" width="20" height="20">
+                                 <path strokeLinecap="round" strokeLinejoin="round" d="M13.19 8.688a4.5 4.5 0 0 1 1.242 7.244l-4.5 4.5a4.5 4.5 0 0 1-6.364-6.364l1.757-1.757m13.35-.622 1.757-1.757a4.5 4.5 0 0 0-6.364-6.364l-4.5 4.5a4.5 4.5 0 0 0 1.242 7.244" />
                             </svg>
+                        </div>
                         Link Bank
                     </PlaidLink>
                 </div>

--- a/client/app/components/homepage/PlaidButtonComponent.js
+++ b/client/app/components/homepage/PlaidButtonComponent.js
@@ -215,23 +215,24 @@ const PlaidLinkComponent = ({ onSuccess }) => {
             ) : error ? (
                 <div className="error-message">{error}</div>
             ) : linkToken ? (
-                <PlaidLink
-                    className="plaid-link-button"
-                    token={linkToken}
-                    onSuccess={handleOnSuccess}
-                    onExit={(error, metadata) =>
-                        console.log("Plaid Link Exit:", error, metadata)
-                    }
-                >
-                    Link Bank Account
-                </PlaidLink>
+                <div className="plaid-link-button-wrapper">
+                    <PlaidLink
+                        className="plaid-link-button"
+                        token={linkToken}
+                        onSuccess={handleOnSuccess}
+                        onExit={(error, metadata) =>
+                            console.log("Plaid Link Exit:", error, metadata)
+                        }
+                    >
+                        Link Bank Account
+                    </PlaidLink>
+                </div>
             ) : (
-                <p>
-                    Something went wrong... Please try again.
-                </p>
+                <p>Something went wrong... Please try again.</p>
             )}
         </div>
     );
+    
 };
 
 export default PlaidLinkComponent;

--- a/client/app/components/singletrip/DownloadTripComponent.js
+++ b/client/app/components/singletrip/DownloadTripComponent.js
@@ -63,14 +63,19 @@ const DownloadTripComponent = ({ tripData, tripId }) => {
             {isModalOpen && (
                 <div className="modal-pdf">
                     <div className="modal-files">
-                        <h3>Select Download Format</h3>
+                        <h3 style={{marginBottom: '-30px'}}>Select Download Format</h3>
+                        <span
+                            className="download-popup-close"
+                            onClick={() => setIsModalOpen(false)}
+                        >
+                            &times;
+                        </span>
                         <button onClick={() => downloadFile('csv')}>CSV</button>
                         <br></br>
                         <button onClick={() => downloadFile('pdf')}>PDF</button>
                         <br></br>
                         <button onClick={() => downloadFile('xml')}>XML</button>
-                        <br></br>
-                        <button onClick={() => setIsModalOpen(false)} className="close-btn">Cancel</button>
+                        {/* <button onClick={() => setIsModalOpen(false)} className="close-btn">Cancel</button> */}
                     </div>
                 </div>
             )}

--- a/client/app/components/singletrip/DownloadTripComponent.js
+++ b/client/app/components/singletrip/DownloadTripComponent.js
@@ -34,8 +34,8 @@ const DownloadTripComponent = ({ tripData, tripId }) => {
             link.parentNode.removeChild(link);
             toast.success(`Trip data downloaded successfully as ${format.toUpperCase()}!`);
         } catch (error) {
-            console.error(`Error downloading trip data in ${format} format:`, error);
-            toast.error(`Error downloading trip data in ${format} format. Please try again.`);
+            console.error(`Error downloading trip data in ${format.toUpperCase()} format:`, error);
+            toast.error(`Error downloading trip data in ${format.toUpperCase()} format. Please try again.`);
         } finally {
             setIsModalOpen(false); // Close modal after download
         }
@@ -64,7 +64,7 @@ const DownloadTripComponent = ({ tripData, tripId }) => {
                 <div className="modal-pdf">
                     <div className="modal-files">
                         <h3>Select Download Format</h3>
-                        <button onClick={() => downloadFile('csv')}>TSV</button>
+                        <button onClick={() => downloadFile('csv')}>CSV</button>
                         <br></br>
                         <button onClick={() => downloadFile('pdf')}>PDF</button>
                         <br></br>

--- a/client/app/components/singletrip/ExpenseFormComponent.js
+++ b/client/app/components/singletrip/ExpenseFormComponent.js
@@ -57,6 +57,9 @@ const ExpenseFormComponent = ({
                         <div className="expense-row-container">
                             <br></br>
 
+                            <div className="upload-section">
+                                <ReceiptImageComponent tripId={tripId} handleFormData={handleFormData} updateIsUploadHidden={updateIsUploadHidden} />
+                            </div>
                             {/* Expense Form */}
                             <form onSubmit={submitNewExpense}>
                                 <label className="new-expense-field-label">
@@ -187,10 +190,6 @@ const ExpenseFormComponent = ({
                                 </label>
                                 <button type="submit" className="submit-new-expense-button">Create</button>
                             </form>
-                            <div className="upload-section">
-                                <ReceiptImageComponent tripId={tripId} handleFormData={handleFormData} updateIsUploadHidden={updateIsUploadHidden} />
-                            </div>
-
                         </div>
                     </div>
                 </div>

--- a/client/app/components/singletrip/ReceiptImageComponent.js
+++ b/client/app/components/singletrip/ReceiptImageComponent.js
@@ -234,7 +234,7 @@ const ReceiptImageComponent = ({ tripId, handleFormData, updateIsUploadHidden })
                 } else {
                     progressBarRef.current.set(currentProgress);
                 }
-            }, 140); 
+            }, 150); 
         });
     };
 
@@ -242,31 +242,6 @@ const ReceiptImageComponent = ({ tripId, handleFormData, updateIsUploadHidden })
         setIsHidden(!isHidden);
         handleHidingImgUploadUpdate()
     }
-
-    // const handleReceiptUpload = async (event) => {
-    //     event.preventDefault();
-    //     if (fileInput.current && fileInput.current.files.length > 0) {
-    //         const imageFile = fileInput.current.files[0]; // get the first file chosen
-
-    //         if (imageFile) { 
-    //             // const formData = new FormData();
-    //             // formData.append('image', imageFile); // 'image' key
-    //             // handleFormData(formData); // passed to expense form component
-
-    //             const reader = new FileReader();
-    //             reader.onloadend = () => {
-    //                 setImageSrc(reader.result); // base64 data URL
-    //             };
-    //             reader.readAsDataURL(imageFile);
-
-    //             // toast.success("Receipt uploaded successfully!");
-    //         }
-    //     }
-    //     else {
-    //         console.error('No file chosen');
-    //         toast.error("Please choose a file to upload.");
-    //     }
-    // };
 
     const handleAutoPreview = (event) => {
         if (fileInput.current && fileInput.current.files.length > 0) {
@@ -286,29 +261,31 @@ const ReceiptImageComponent = ({ tripId, handleFormData, updateIsUploadHidden })
     };
     
     return (
-        <div className={`receipt-upload-container ${isHidden ? 'hidden' : ''}`}>
-            {/* Icon to open up receipt upload container */}
-            <div className="top-left-button-container">
-            <button 
-                onClick={toggleHideBar} 
-                className="receipt-upload-button">
-                <svg 
-                    xmlns="http://www.w3.org/2000/svg" 
-                    fill="none" 
-                    viewBox="0 0 24 24" 
-                    strokeWidth="1.3" 
-                    stroke="currentColor" 
+    <div>
+        {/* Icon to open up receipt upload container */}
+        <div className={`receipt-button-container ${isHidden ? 'hidden' : ''}`}>
+            <button
+                onClick={toggleHideBar}
+                className={`receipt-upload-button ${isHidden ? 'hidden' : ''}`}>
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    strokeWidth="1.3"
+                    stroke="currentColor"
                     className="size-6"
                 >
-                    <path 
-                        strokeLinecap="round" 
-                        strokeLinejoin="round" 
-                        d="m9 14.25 6-6m4.5-3.493V21.75l-3.75-1.5-3.75 1.5-3.75-1.5-3.75 1.5V4.757c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0 1 11.186 0c1.1.128 1.907 1.077 1.907 2.185ZM9.75 9h.008v.008H9.75V9Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm4.125 4.5h.008v.008h-.008V13.5Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z" 
+                    <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="m9 14.25 6-6m4.5-3.493V21.75l-3.75-1.5-3.75 1.5-3.75-1.5-3.75 1.5V4.757c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0 1 11.186 0c1.1.128 1.907 1.077 1.907 2.185ZM9.75 9h.008v.008H9.75V9Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm4.125 4.5h.008v.008h-.008V13.5Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z"
                     />
                 </svg>
                 <span className="button-text">Receipt</span>
             </button>
         </div>
+    
+        <div className={`receipt-upload-container ${isHidden ? 'hidden' : ''}`}>
             <div className={`receipt-upload-form ${isHidden ? 'hidden' : ''}`}>
                 <h6 className="receipt-upload-title">Upload a Receipt</h6>
                 <form encType="multipart/form-data" className="receipt-upload-form-content">
@@ -343,12 +320,13 @@ const ReceiptImageComponent = ({ tripId, handleFormData, updateIsUploadHidden })
                             className="receipt-preview-image"
                         />
                     ) : (
-                        <p>No receipt preview available.</p>
+                        <p></p>
                     )}
                 </div>
                 {/* Progress Bar */}
                 <div id="progress-container" className="progress-bar-container"></div>
             </div>
+        </div>
         </div>
     
     );

--- a/client/app/css/downloadExpenses.css
+++ b/client/app/css/downloadExpenses.css
@@ -28,6 +28,16 @@
     color: #333;
 }
 
+.download-popup-close {
+    position: relative;
+    top: -2px;
+    left: -128px;
+    color: #aaa;
+    font-size: 28px;
+    font-weight: bold;
+    cursor: pointer;
+}
+
 .modal-files button {
     background-color: var(--lightgreen);
     color: white;

--- a/client/app/css/plaid.css
+++ b/client/app/css/plaid.css
@@ -17,13 +17,17 @@
 .plaid-link-button {
     background-color: var(--lightgreen)!important; 
     color: white;
-    padding: 12px 24px !important; 
-    border: none;
+    padding: 15px 30px !important;
+    border: none !important;
     border-radius: 10px !important; 
     font-size: 15px;
     cursor: pointer;
     transition: background-color 0.3s ease-in-out;
     text-align: center; 
+    display: flex;
+    justify-content: center;
+    margin: 30px auto;
+    margin-right: -60px;
 }
 
 .plaid-link-button:hover {
@@ -35,5 +39,11 @@
     .plaid-link-container {
         width: 100%;
         margin-top: -5%; 
+    }
+}
+
+@media (max-width: 1300px) {
+    .plaid-link-button-wrapper {
+        transform: translateX(-130px);
     }
 }

--- a/client/app/css/receiptImage.css
+++ b/client/app/css/receiptImage.css
@@ -1,3 +1,12 @@
+.receipt-upload-container.hidden {
+    box-shadow: none;
+    background-color: transparent;
+    border: none;
+    padding: 0;
+    position: relative;
+    margin: 0;
+}
+
 .receipt-upload-container {
     display: flex;
     flex-direction: column;
@@ -8,6 +17,82 @@
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
     max-width: 800px;
     margin: 20px auto;
+    position: relative;
+    margin-right: 50px;
+}
+
+@media (max-width: 929px) {
+    .receipt-upload-container {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        padding: 20px;
+        border: 0.7px solid #ddd;
+        border-radius: 12px;
+        box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+        max-width: 800px;
+        margin: 20px auto;
+        position: relative;
+        margin-right: 0px;
+        margin-top: -70px;
+    }
+
+    .receipt-upload-container.hidden {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        padding: 20px;
+        border: none;
+        border-radius: 12px;
+        box-shadow: none;
+        max-width: 800px;
+        margin: 20px auto;
+        position: relative;
+        margin-right: 0px;
+        margin-top: -70px;
+        margin-bottom: -200px !important;
+    }
+
+    .receipt-button-container {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        margin-bottom: 30px;
+        width: 100%;
+    }
+
+    .receipt-button-container {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        width: 100%;
+        margin-bottom: 100px !important;
+        margin-top: -30px;
+        margin-left: 30px;
+    }
+
+    .receipt-button-container.hidden {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        width: 100%;
+        margin-left: 30px;
+    }
+
+    .receipt-button-container.hidden {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        width: 100%;
+        margin-bottom: -30px !important;
+        margin-top: -90px;
+        margin-left: 0px;
+    }
+
+    .receipt-upload-form.hidden {
+        width: 100%;
+        margin-top: -20px;
+    }
 }
 
 .receipt-upload-button,
@@ -22,16 +107,35 @@
     box-shadow: none;
 }
 
-.receipt-upload-button {
+
+.receipt-upload-button.hidden {
     background-color: transparent;
-    color: #fff;
     border: none;
     cursor: pointer;
     padding: 10px 15px;
     border-radius: 8px;
     font-size: 16px;
     font-weight: bold;
+    display: flex;
+    align-items: center;
     transition: background-color 0.3s ease;
+    margin-right: 0px;
+    margin-bottom: -20px;
+}
+
+.receipt-upload-button {
+    background-color: transparent;
+    border: none;
+    cursor: pointer;
+    padding: 10px 15px;
+    border-radius: 8px;
+    font-size: 16px;
+    font-weight: bold;
+    display: flex;
+    align-items: center;
+    transition: background-color 0.3s ease;
+    margin-right: 65px;
+    margin-bottom: -20px;
 }
 
 .receipt-upload-button svg,
@@ -43,9 +147,8 @@
 }
 
 .receipt-upload-button svg {
-    width: 25px !important;
-    height: 25px !important;
-    margin-left: 0px !important;
+    width: 25px;
+    height: 25px;
     margin-right: 5px;
 }
 
@@ -70,18 +173,20 @@
     display: none;
 }
 
-.receipt-upload-container.hidden {
-    box-shadow: none;
-    background-color: transparent;
+.receipt-button-container.hidden {
     position: absolute;
-    top: 5%;
-    left: 40px;
-    width: fit-content;
-    padding: 15px 30px;
-    border: none;
-    border-radius: 10px;
-    font-size: 15px;
-    cursor: pointer;
+    top: 10px;
+    left: -4px;
+    z-index: 10;
+    margin-top: 60px;  
+}
+
+.receipt-button-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-bottom: 30px;
+    width: 100%;
 }
 
 .receipt-upload-title {
@@ -135,6 +240,7 @@
     top: 10%;
     left: 35px;
     z-index: 10;
+    margin-right: 20px;
 }
 
 .input-button-container {

--- a/client/app/css/sharedUsersComponent.css
+++ b/client/app/css/sharedUsersComponent.css
@@ -74,9 +74,10 @@
 
 /* homepage-specific adjustments */
 .whole_container.homepage-size {
-    position:absolute;
+    position: absolute;
     top: 87%;
     left: 20%;
+    right: 0%;
 }
 
 .shared-user.homepage-user {

--- a/client/app/css/singletrip.css
+++ b/client/app/css/singletrip.css
@@ -483,6 +483,7 @@
     font-size: 20px;
     margin-bottom: 15px;
     text-align: center;
+    font-weight: bold;
 }
 
 .filter-option-button {

--- a/client/app/css/singletrip.css
+++ b/client/app/css/singletrip.css
@@ -263,7 +263,7 @@
     /* padding: 8px;
     width: 90%; */
     padding: 15px 30px;
-    background-color: #8B0000;
+    background-color: rgb(235, 5, 5);
     color: white;
     border: none;
     width: 50%;
@@ -517,7 +517,6 @@
     width: 155px;
     height: 40px;
 }
-
 
 .clear-filter-btn {
     background: none;
@@ -894,18 +893,20 @@
 }
 
 .expense-row-container {
-    display: flex;
     justify-content: space-between;
-    align-items: center;
     padding: 5px;
     padding-right: 0px;
     margin-top: 40px;
+    display: flex; /* Use flex to align items inside */
+    justify-content: center;
+    align-items: center;
 }
 
 @media (max-width: 929px) {
     .expense-row-container {
         flex-direction: column; /* vertical layout */
         gap: 20px; 
+        margin-top: -24px;
     }
      /* disable wide form */
     .new-expense-modal.wide-form {
@@ -916,12 +917,11 @@
 }
 
 .upload-section {
-    margin-left: 10px;
     display: flex;
-    justify-content: center;
-    align-items: center;
+    justify-content: center; 
+    align-items: center; 
+    height: 100%;
 }
-
 
 .toggle-container {
     margin: 30px auto;

--- a/client/app/globals.css
+++ b/client/app/globals.css
@@ -102,12 +102,11 @@ a {
   position: absolute; 
   right: 0; 
   background-color: var(--lightgreen);
-  border: 1px solid rgba(0, 0, 0, 0.1);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2); 
+  box-shadow: 0 5px 10px rgba(0, 0, 0, 0.4); 
   z-index: 10000;
   display: flex;
   flex-direction: column; 
-  border-radius: 12px;
+  border-radius: 8px;
   overflow: hidden; 
   min-width: 150px;
   transition: all 0.3s ease;

--- a/client/app/page.module.css
+++ b/client/app/page.module.css
@@ -13,7 +13,7 @@
   min-height: 100svh;
   padding: 80px;
   gap: 64px;
-  font-family: var(--font-geist-sans);
+  font-family: Arial, Helvetica, sans-serif;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -35,7 +35,7 @@
 }
 
 .main ol {
-  font-family: var(--font-geist-mono);
+  font-family: Arial, Helvetica, sans-serif;
   padding-left: 0;
   margin: 0;
   font-size: 14px;
@@ -49,7 +49,7 @@
 }
 
 .main code {
-  font-family: inherit;
+  font-family: Arial, Helvetica, sans-serif;
   background: var(--gray-alpha-100);
   padding: 2px 4px;
   border-radius: 4px;


### PR DESCRIPTION
## Description
- The purpose of this PR is to update the styling and positioning of the receipt upload section, and tweak styling throughout for consistency.
- This PR belongs to tickets #347 and #244 
- Overview of files changed below.

## What’s in this change?
- receiptImage.css, ReceiptImageComponent.js
  - Updated positioning of the receipt upload to be on the right when window size is large, and for smaller window sizes, it's stacked above the input fields.
  - Responsive design added when the toggle is selected/unselected when window sizes vary.
- DownloadTripComponent.js, downloadExpenses.css
  - Removed Cancel button and replaced with a 'x' button to match all other forms.
- PlaidButtonComponent.js, plaid.css
  - Re-positioned the link/unlink icons to make it more visually aligned.
  - Added responsiveness to the link/unlink bank buttons.
- SharedUsersComponent.js
  - Shifted the shared users in the homepage slightly to the right to make it visually appealing.
- singletrip.css, globals.css, page.module.css
  - Minor styling changes: matched the Delete expense button to the delete icon hover color for consistency.
  - Centered the receipt toggle.
  - Changed fonts to match throughout.
  - Removed border of logout dropdown.

- Main Change
BEFORE (receipt upload):
<img width="1281" alt="Screenshot 2024-12-10 at 2 42 07 PM" src="https://github.com/user-attachments/assets/ced083f6-4453-4254-93ca-e9fdd4a1a61c">
<img width="1265" alt="Screenshot 2024-12-10 at 2 42 31 PM" src="https://github.com/user-attachments/assets/bc8fa4f6-1628-4cf7-8b99-cf85149d4e90">
<img width="450" alt="Screenshot 2024-12-10 at 2 42 42 PM" src="https://github.com/user-attachments/assets/0101fe8f-6973-493c-a008-cbab9186ed0f">

 
AFTER (receipt upload):
<img width="1500" alt="Screenshot 2024-12-10 at 2 38 05 PM" src="https://github.com/user-attachments/assets/566cc1e8-70c9-433a-a104-2c779b407830">
<img width="1500" alt="Screenshot 2024-12-10 at 2 38 31 PM" src="https://github.com/user-attachments/assets/a6d9d02e-a201-43d1-890d-536c6d97c346">
<img width="450" alt="Screenshot 2024-12-10 at 2 38 17 PM" src="https://github.com/user-attachments/assets/88b5da65-0082-4cef-bc01-35c7a6eb5c34">
<img width="450" alt="Screenshot 2024-12-10 at 2 38 44 PM" src="https://github.com/user-attachments/assets/b414103e-e1c0-4b60-a467-e830feb0701e">

## Testing Changes
- No new testing; frontend only.
