### PR TITLE
Fixed application error

### DIFF
--- a/client/app/components/singletrip/ExpenseSuggestionsComponent.js
+++ b/client/app/components/singletrip/ExpenseSuggestionsComponent.js
@@ -67,7 +67,7 @@ const ExpenseSuggestionsComponent = ({
 
             const token = localStorage.getItem("access_token");
             if (!token) {
-                toast.error("Plaid token not found.");
+                toast.warn("Connect Plaid to get suggested expenses.");
                 return;
             }
 
@@ -95,7 +95,7 @@ const ExpenseSuggestionsComponent = ({
     };
 
     useEffect(() => {
-        if (userId && tripData) {
+        if (userId && tripData && isPlaidConnected) {
             fetchSuggestedExpenses();
         }
     }, [userId, tripData]);


### PR DESCRIPTION
## Description
- Debugging: The purpose of this PR is to fix the application error that occurs after the "Plaid token not found" message when Plaid is not connected.
- This ticket belongs to #325.
## What’s in this change?
- ExpenseSuggestionsComponent.js
  - Ensure Plaid is connected before fetching suggested expenses.

## Testing Changes
- Unit test coverage report
